### PR TITLE
Be able to use rack 2.x for Rails 5

### DIFF
--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version     = '>= 2.0.0'
 
-  spec.add_dependency 'rack', '~> 1.6'
+  spec.add_dependency 'rack', '>= 1.6'
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Rails 5 (beta 3) requires `rack ~> 2.x` .
I want to use this gem with Rails 5.