### PR TITLE
Support client access with proxy

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -11,7 +11,7 @@ module Line
     class Client
 
       #  @return [String]
-      attr_accessor :channel_id, :channel_secret, :channel_mid, :endpoint, :to_channel_id
+      attr_accessor :channel_id, :channel_secret, :channel_mid, :endpoint, :to_channel_id, :http_proxy
 
       # Initialize a new Bot Client.
       #
@@ -176,6 +176,7 @@ module Line
           config.credentials    = credentials
           config.to_mid         = to_mid
           config.message        = message
+          config.http_proxy     = http_proxy
         end
 
         request.post
@@ -240,6 +241,7 @@ module Line
           config.endpoint       = endpoint
           config.endpoint_path  = endpoint_path
           config.credentials    = credentials
+          config.http_proxy     = http_proxy
         end
 
         request.get

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -11,7 +11,7 @@ module Line
     class Client
 
       #  @return [String]
-      attr_accessor :channel_id, :channel_secret, :channel_mid, :endpoint, :to_channel_id, :http_proxy
+      attr_accessor :channel_id, :channel_secret, :channel_mid, :endpoint, :to_channel_id, :proxy
 
       # Initialize a new Bot Client.
       #
@@ -176,7 +176,7 @@ module Line
           config.credentials    = credentials
           config.to_mid         = to_mid
           config.message        = message
-          config.http_proxy     = http_proxy
+          config.proxy          = proxy
         end
 
         request.post
@@ -241,7 +241,7 @@ module Line
           config.endpoint       = endpoint
           config.endpoint_path  = endpoint_path
           config.credentials    = credentials
-          config.http_proxy     = http_proxy
+          config.proxy          = proxy
         end
 
         request.get

--- a/lib/line/bot/request.rb
+++ b/lib/line/bot/request.rb
@@ -18,9 +18,10 @@ module Line
       # @return [Net::HTTP]
       def https
         uri = URI(endpoint)
-        proxy_uri = URI(http_proxy ||= "")
-        https = Net::HTTP.new(uri.host, uri.port, proxy_uri.host || :ENV, proxy_uri.port, proxy_uri.user, proxy_uri.password)
-        if proxy_uri.scheme == "https" || (!proxy_uri.scheme && uri.scheme == "https")
+        proxy_uri = URI(@http_proxy ||= "")
+        proxy = Net::HTTP.Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+        https = proxy.new(uri.host, uri.port)
+        if uri.scheme == "https"
           https.use_ssl = true
         end
 

--- a/lib/line/bot/request.rb
+++ b/lib/line/bot/request.rb
@@ -20,7 +20,7 @@ module Line
         uri = URI(endpoint)
         proxy_uri = URI(http_proxy ||= "")
         https = Net::HTTP.new(uri.host, uri.port, proxy_uri.host || :ENV, proxy_uri.port, proxy_uri.user, proxy_uri.password)
-        if uri.scheme == "https"
+        if proxy_uri.scheme == "https" || (!proxy_uri.scheme && uri.scheme == "https")
           https.use_ssl = true
         end
 

--- a/lib/line/bot/request.rb
+++ b/lib/line/bot/request.rb
@@ -6,7 +6,7 @@ require 'uri'
 module Line
   module Bot
     class Request
-      attr_accessor :endpoint, :endpoint_path, :credentials, :to_mid, :message, :to_channel_id, :http_proxy
+      attr_accessor :endpoint, :endpoint_path, :credentials, :to_mid, :message, :to_channel_id, :proxy
 
       # Initializes a new Request
       #
@@ -18,9 +18,9 @@ module Line
       # @return [Net::HTTP]
       def https
         uri = URI(endpoint)
-        proxy_uri = URI(@http_proxy ||= "")
-        proxy = Net::HTTP.Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
-        https = proxy.new(uri.host, uri.port)
+        proxy_uri = URI(@proxy ||= "")
+        proxy_http = Net::HTTP.Proxy(proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
+        https = proxy_http.new(uri.host, uri.port)
         if uri.scheme == "https"
           https.use_ssl = true
         end

--- a/lib/line/bot/request.rb
+++ b/lib/line/bot/request.rb
@@ -6,7 +6,7 @@ require 'uri'
 module Line
   module Bot
     class Request
-      attr_accessor :endpoint, :endpoint_path, :credentials, :to_mid, :message, :to_channel_id
+      attr_accessor :endpoint, :endpoint_path, :credentials, :to_mid, :message, :to_channel_id, :http_proxy
 
       # Initializes a new Request
       #
@@ -18,7 +18,8 @@ module Line
       # @return [Net::HTTP]
       def https
         uri = URI(endpoint)
-        https = Net::HTTP.new(uri.host, uri.port)
+        proxy_uri = URI(http_proxy ||= "")
+        https = Net::HTTP.new(uri.host, uri.port, proxy_uri.host || :ENV, proxy_uri.port, proxy_uri.user, proxy_uri.password)
         if uri.scheme == "https"
           https.use_ssl = true
         end


### PR DESCRIPTION
This gem isn't support to use client via http proxy server.
I want to use this gem with the static IP address proxy such as [FIXIE](http://usefixie.com/) .

I think this pull request needs spec for client with proxy.
But I can't find how to test http access with proxy.
Please tell me how to do it if you know.