### PR TITLE
Add get_display_name

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -175,6 +175,17 @@ module Line
         get(endpoint_path)
       end
 
+      # Get an user's display name.
+      #
+      # @param user_id [String] User's identifiers
+      #
+      # @return [String]
+      def get_display_name(user_id)
+        response = get_profile(user_id)
+        json = JSON.parse(response.body)
+        json['displayName']
+      end
+
       # Fetch data, get content of specified URL.
       #
       # @param endpoint_path [String]


### PR DESCRIPTION
I want to get displayName from userId directly.
But `get_profile` method returns raw `Net::HTTPResponse` object.
Should I parse it in my app's code?

My p-r has problem that if anyone want to get other profile information(e.g. `pictureUrl`) , they have to call same API many times.

In order to resolve it I would add `User` class(e.g. `Line::Bot::User`) and set parsed `get_profile`'s result.
How about do you think?


https://devdocs.line.me/ja/#bot-api-get-profile