### PR TITLE
Update links in docs

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 ## Do this before creating an issue
 
-- Check the [FAQ](https://github.com/line/line-bot-faq) for LINE bots
-- Make sure your issue is **related to** the LINE Bot SDK. For general questions or issues about LINE bots, create an issue on the [FAQ](https://github.com/line/line-bot-faq) repository. Note that we don't provide technical support.
+- Check our [developer documentation](https://developers.line.me/en/docs/) and [FAQ](https://developers.line.me/en/faq/messaging-api/) page for more information on LINE bots and the Messaging API
+- Make sure your issue is **related to** the LINE Bot SDK. For general questions or issues about LINE bots, create an issue on the [LINE Platform feedback](https://github.com/line/line-platform-feedback) repository. Note that we don't provide technical support.
 
 ## When creating an issue
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Line::Bot::API - SDK of the LINE Messaging API for Ruby.
 
 See the official API reference documentation for more information.
 
-https://devdocs.line.me/
+https://developers.line.me/en/docs/messaging-api/reference/
 
 ## Synopsis
 


### PR DESCRIPTION
Issue template
- Adds links to:
  - [LINE Developers site](https://developers.line.me/en/docs/)
  - [LINE Developers FAQ page (Messaging API)](https://developers.line.me/en/faq/messaging-api/)
- Fixes:
  - Link to https://github.com/line/line-platform-feedback
- Revises text

README
- Update link