### PR TITLE
Feature/add net open timeout option

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -27,6 +27,9 @@ module Line
       # @return [Object]
       attr_accessor :httpclient
 
+      # @return [Numeric]
+      attr_accessor :net_open_timeout
+
       # Initialize a new Bot Client.
       #
       # @param options [Hash]
@@ -40,7 +43,7 @@ module Line
       end
 
       def httpclient
-        @httpclient ||= Line::Bot::HTTPClient.new
+        @httpclient ||= Line::Bot::HTTPClient.new(net_open_timeout)
       end
 
       def endpoint

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -27,8 +27,8 @@ module Line
       # @return [Object]
       attr_accessor :httpclient
 
-      # @return [Numeric]
-      attr_reader :net_open_timeout
+      # @return [Hash]
+      attr_accessor :http_options
 
       # Initialize a new Bot Client.
       #
@@ -40,11 +40,10 @@ module Line
           instance_variable_set("@#{key}", value)
         end
         yield(self) if block_given?
-        varidate_net_open_timeout if defined?(@net_open_timeout)
       end
 
       def httpclient
-        @httpclient ||= Line::Bot::HTTPClient.new(net_open_timeout)
+        @httpclient ||= Line::Bot::HTTPClient.new(http_options)
       end
 
       def endpoint
@@ -425,10 +424,6 @@ module Line
         res = 0
         b.each_byte { |byte| res |= byte ^ l.shift }
         res == 0
-      end
-
-      def varidate_net_open_timeout
-        raise ArgumentError, 'net_open_timeout must be positive Numeric' if net_open_timeout.nil? || net_open_timeout < 0
       end
     end
   end

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -28,7 +28,7 @@ module Line
       attr_accessor :httpclient
 
       # @return [Numeric]
-      attr_accessor :net_open_timeout
+      attr_reader :net_open_timeout
 
       # Initialize a new Bot Client.
       #
@@ -40,6 +40,7 @@ module Line
           instance_variable_set("@#{key}", value)
         end
         yield(self) if block_given?
+        varidate_net_open_timeout if defined?(@net_open_timeout)
       end
 
       def httpclient
@@ -424,6 +425,10 @@ module Line
         res = 0
         b.each_byte { |byte| res |= byte ^ l.shift }
         res == 0
+      end
+
+      def varidate_net_open_timeout
+        raise ArgumentError, 'net_open_timeout must be positive Numeric' if net_open_timeout.nil? || net_open_timeout < 0
       end
     end
   end

--- a/lib/line/bot/httpclient.rb
+++ b/lib/line/bot/httpclient.rb
@@ -39,8 +39,10 @@ module Line
           http.use_ssl = true
         end
 
-        http_options&.each do |key, value|
-          http.send("#{key}=", value)
+        if http_options
+          http_options.each do |key, value|
+            http.send("#{key}=", value)
+          end
         end
 
         http

--- a/lib/line/bot/httpclient.rb
+++ b/lib/line/bot/httpclient.rb
@@ -20,12 +20,26 @@ require 'uri'
 module Line
   module Bot
     class HTTPClient
+      #  @return [Numeric]
+      attr_accessor :net_open_timeout
+
+      # Initialize a new HTTPClient
+      #
+      # @param net_open_timeout [Integer]
+      #
+      # @return [Line::Bot::HTTPClient]
+      def initialize(net_open_timeout = nil)
+        @net_open_timeout = net_open_timeout
+      end
+
       # @return [Net::HTTP]
       def http(uri)
         http = Net::HTTP.new(uri.host, uri.port)
         if uri.scheme == "https"
           http.use_ssl = true
         end
+
+        http.open_timeout = net_open_timeout if net_open_timeout
 
         http
       end

--- a/lib/line/bot/httpclient.rb
+++ b/lib/line/bot/httpclient.rb
@@ -20,16 +20,16 @@ require 'uri'
 module Line
   module Bot
     class HTTPClient
-      #  @return [Numeric]
-      attr_accessor :net_open_timeout
+      #  @return [Hash]
+      attr_accessor :http_options
 
       # Initialize a new HTTPClient
       #
-      # @param net_open_timeout [Integer]
+      # @param http_options [Hash]
       #
       # @return [Line::Bot::HTTPClient]
-      def initialize(net_open_timeout = nil)
-        @net_open_timeout = net_open_timeout
+      def initialize(http_options = {})
+        @http_options = http_options
       end
 
       # @return [Net::HTTP]
@@ -39,7 +39,9 @@ module Line
           http.use_ssl = true
         end
 
-        http.open_timeout = net_open_timeout if net_open_timeout
+        http_options&.each do |key, value|
+          http.send("#{key}=", value)
+        end
 
         http
       end


### PR DESCRIPTION
I implemented this for the following reasons

- Response speed is important for Bot
- `Net::OpenTimeout` rarely occurs (ref: https://github.com/line/line-bot-sdk-ruby/issues/84)
- Sometimes I want to retry quickly