### PR TITLE
Add functions for default rich menu

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -376,7 +376,7 @@ module Line
       # @param endpoint_path [String]
       #
       # @return [Net::HTTPResponse]
-      def post(endpoint_path, payload=nil)
+      def post(endpoint_path, payload = nil)
         raise Line::Bot::API::InvalidCredentialsError, 'Invalidates credentials' unless credentials?
 
         request = Request.new do |config|

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -280,6 +280,24 @@ module Line
         get(endpoint_path)
       end
 
+      # Set default rich menu (Link a rich menu to all user)
+      #
+      # @param rich_menu_id [String] ID of an uploaded rich menu
+      #
+      # @return [Net::HTTPResponse]
+      def set_default_rich_menu(rich_menu_id)
+        endpoint_path = "/bot/user/all/richmenu/#{rich_menu_id}"
+        post(endpoint_path)
+      end
+
+      # Unset default rich menu (Unlink a rich menu from all user)
+      #
+      # @return [Net::HTTPResponse]
+      def unset_default_rich_menu
+        endpoint_path = "/bot/user/all/richmenu"
+        delete(endpoint_path)
+      end
+
       # Link a rich menu to a user
       #
       # @param user_id [String] ID of the user

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -371,6 +371,25 @@ module Line
         request.get
       end
 
+      # Post data, get content of specified URL.
+      #
+      # @param endpoint_path [String]
+      #
+      # @return [Net::HTTPResponse]
+      def post(endpoint_path, payload=nil)
+        raise Line::Bot::API::InvalidCredentialsError, 'Invalidates credentials' unless credentials?
+
+        request = Request.new do |config|
+          config.httpclient     = httpclient
+          config.endpoint       = endpoint
+          config.endpoint_path  = endpoint_path
+          config.credentials    = credentials
+          config.payload        = payload if payload
+        end
+
+        request.post
+      end
+
       # Delete content of specified URL.
       #
       # @param endpoint_path [String]

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -95,6 +95,22 @@ describe Line::Bot::Client do
     expect(response.body).to eq '{"richMenuId":"7654321"}'
   end
 
+  it 'set a default rich menu' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/all/richmenu/7654321'
+    stub_request(:post, uri_template).to_return(body: '{}', status: 200)
+
+    client.set_default_rich_menu('7654321')
+    expect(WebMock).to have_requested(:post, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/all/richmenu/7654321')
+  end
+
+  it 'unset a default rich menu' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/all/richmenu'
+    stub_request(:delete, uri_template).to_return(body: '{}', status: 200)
+
+    client.unset_default_rich_menu()
+    expect(WebMock).to have_requested(:delete, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/all/richmenu')
+  end
+
   it 'links a rich menu to a user' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/1234567/richmenu/7654321'
     stub_request(:post, uri_template).to_return(body: '{}', status: 200)

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -107,7 +107,7 @@ describe Line::Bot::Client do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/all/richmenu'
     stub_request(:delete, uri_template).to_return(body: '{}', status: 200)
 
-    client.unset_default_rich_menu()
+    client.unset_default_rich_menu
     expect(WebMock).to have_requested(:delete, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/all/richmenu')
   end
 


### PR DESCRIPTION
・Add `set_default_rich_menu` function and `unset_default_rich_menu` function to lib/line/bot/client.rb

Although developers can set/unset default rich menu by using `link_user_rich_menu` / `unlink_user_rich_menu` functions with `"all"`, I suggest that we should stipulate the functions only for default rich menu (or add explanation of using `"all"` to using `link_user_rich_menu` / `unlink_user_rich_menu` functions).

This change make this library a little bit easier to use.