### PR TITLE
Support account link event

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -17,7 +17,6 @@ require 'line/bot/api/errors'
 require 'base64'
 require 'net/http'
 require 'openssl'
-require 'active_support/core_ext/string/inflections'
 
 module Line
   module Bot
@@ -419,7 +418,7 @@ module Line
 
         json['events'].map { |item|
           begin
-            klass = Line::Bot::Event.const_get(item['type'].camelize)
+            klass = Line::Bot::Event.const_get(camelize(item['type']))
             klass.new(item)
           rescue NameError => e
             Line::Bot::Event::Base.new(item)
@@ -462,6 +461,11 @@ module Line
         res = 0
         b.each_byte { |byte| res |= byte ^ l.shift }
         res == 0
+      end
+
+      # @return [String]
+      def camelize(string)
+        string.split(/_|(?=[A-Z])/).map(&:capitalize).join
       end
     end
   end

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -17,6 +17,7 @@ require 'line/bot/api/errors'
 require 'base64'
 require 'net/http'
 require 'openssl'
+require 'active_support/core_ext/string/inflections'
 
 module Line
   module Bot
@@ -418,7 +419,7 @@ module Line
 
         json['events'].map { |item|
           begin
-            klass = Line::Bot::Event.const_get(item['type'].capitalize)
+            klass = Line::Bot::Event.const_get(item['type'].camelize)
             klass.new(item)
           rescue NameError => e
             Line::Bot::Event::Base.new(item)

--- a/lib/line/bot/event/account_link.rb
+++ b/lib/line/bot/event/account_link.rb
@@ -12,12 +12,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-require 'line/bot/event/base'
-require 'line/bot/event/account_link'
-require 'line/bot/event/beacon'
-require 'line/bot/event/follow'
-require 'line/bot/event/join'
-require 'line/bot/event/leave'
-require 'line/bot/event/message'
-require 'line/bot/event/postback'
-require 'line/bot/event/unfollow'
+module Line
+  module Bot
+    module Event
+      class AccountLink < Base
+        def result
+          @src['link']['result']
+        end
+
+        def nonce
+          @src['link']['nonce']
+        end
+      end
+    end
+  end
+end

--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version     = '>= 2.0.0'
 
-  spec.add_runtime_dependency "activesupport"
-
   spec.add_development_dependency "addressable", "~> 2.3"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency 'rake', "~> 10.4"

--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version     = '>= 2.0.0'
 
+  spec.add_runtime_dependency "activesupport"
+
   spec.add_development_dependency "addressable", "~> 2.3"
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency 'rake', "~> 10.4"

--- a/spec/line/bot/client_parse_spec.rb
+++ b/spec/line/bot/client_parse_spec.rb
@@ -145,6 +145,19 @@ EVENTS_CONTENT = <<"EOS"
         "type": "enter",
         "dm": "1234567890abcdef"
       }
+    },
+    {
+      "type": "accountLink",
+      "replyToken": "replyToken",
+      "source": {
+        "type": "user",
+        "userId": "userid"
+      },
+      "timestamp": 12345678901234,
+      "link": {
+        "result": "ok",
+        "nonce": "nonce"
+      }
     }
   ]
 }
@@ -251,6 +264,10 @@ describe Line::Bot::Client do
     expect(events[11].type).to eq("enter")
     expect(events[11]['beacon']['dm']).to eq("1234567890abcdef")
     expect(events[11].deviceMessage).to eq("\x12\x34\x56\x78\x90\xab\xcd\xef".b)
+
+    expect(events[12]).to be_a(Line::Bot::Event::AccountLink)
+    expect(events[12].result).to eq("ok")
+    expect(events[12].nonce).to eq("nonce")
   end
 
   it 'parses unknown event' do


### PR DESCRIPTION
Account Link Event:
https://developers.line.biz/en/reference/messaging-api/#account-link-event

This change eases catching `accountLink` events like:

```ruby
events = client.parse_events_from(body)
events.each do |event|
  case event
  when Line::Bot::Event::AccountLink
    puts event.result
    puts event.nonce
  end
end
```

On the other hand, it can break existing applications which catches `accountLink` events as `Line::Bot::Event::Base` like: 

```ruby
events = client.parse_events_from(body)
events.each do |event|
  case event
  when Line::Bot::Event::Base
    case event['type']
    when 'accountLink'
      # do something
    end
  end
end
```

So, if this change is merged, I think the major version should be bumped up.