### PR TITLE
Add helper for bundler to auto require

### DIFF
--- a/lib/line-bot-api.rb
+++ b/lib/line-bot-api.rb
@@ -1,0 +1,1 @@
+require 'line/bot'


### PR DESCRIPTION
Currently, if we add `line-bot-api` via bundler, we need to manually add `require 'line-bot-api'`. This pull request adds a simple helper to make auto require work.