### PR TITLE
Make CI run on Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
 before_install:
   - if [ ${TRAVIS_RUBY_VERSION} = '2.2' ]; then


### PR DESCRIPTION
Ruby 2.6 was released last Christmas, and we should add it to CI test.

https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/