### PR TITLE
Improve code example in README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ post '/callback' do
   end
 
   events = client.parse_events_from(body)
-  events.each { |event|
+  events.each do |event|
     case event
     when Line::Bot::Event::Message
       case event.type
@@ -52,7 +52,7 @@ post '/callback' do
         tf.write(response.body)
       end
     end
-  }
+  end
 
   "OK"
 end

--- a/examples/echobot/app.rb
+++ b/examples/echobot/app.rb
@@ -18,7 +18,7 @@ post '/callback' do
 
   events = client.parse_events_from(body)
 
-  events.each { |event|
+  events.each do |event|
     case event
     when Line::Bot::Event::Message
       case event.type
@@ -30,7 +30,7 @@ post '/callback' do
         client.reply_message(event['replyToken'], message)
       end
     end
-  }
+  end
 
   "OK"
 end


### PR DESCRIPTION
Now it uses do/end style of block for a long block.
It follows standard coding convention of Ruby.
See: https://github.com/rubocop-hq/ruby-style-guide#single-line-blocks