### PR TITLE
Fix HTTP status code check

### DIFF
--- a/examples/kitchensink/app.rb
+++ b/examples/kitchensink/app.rb
@@ -31,7 +31,7 @@ def reply_content(event, messages)
     event['replyToken'],
     messages
   )
-  puts res.read_body if res.code != 200
+  puts res.read_body unless Net::HTTPOK === res
 end
 
 post '/callback' do


### PR DESCRIPTION
Net::HTTPResponse#code returns a value with String.
see: https://docs.ruby-lang.org/ja/latest/class/Net=3a=3aHTTPResponse.html#I_CODE

So `res.code != 200` had always returned truthy regardless of actual status code.

Thanks!