### PR TITLE
Fix wrong #error method usage

### DIFF
--- a/examples/echobot/app.rb
+++ b/examples/echobot/app.rb
@@ -13,7 +13,7 @@ post '/callback' do
 
   signature = request.env['HTTP_X_LINE_SIGNATURE']
   unless client.validate_signature(body, signature)
-    error 400 do 'Bad Request' end
+    halt 400, {'Content-Type' => 'text/plain'}, 'Bad Request'
   end
 
   events = client.parse_events_from(body)

--- a/examples/kitchensink/app.rb
+++ b/examples/kitchensink/app.rb
@@ -40,7 +40,7 @@ post '/callback' do
 
   signature = request.env['HTTP_X_LINE_SIGNATURE']
   unless client.validate_signature(body, signature)
-    error 400 do 'Bad Request' end
+    halt 400, {'Content-Type' => 'text/plain'}, 'Bad Request'
   end
 
   events = client.parse_events_from(body)


### PR DESCRIPTION
We have used a following code to return error response.

```rb
error 400 do 'Bad Request' end
```

But in action context, `#error` method is [Sinatra::Helpers#error](https://github.com/sinatra/sinatra/blob/eee711b/lib/sinatra/base.rb#L306-L310), not [Sinatra::Delegator#error](https://github.com/sinatra/sinatra/blob/eee711b/lib/sinatra/base.rb#L1923).

So we may change it to:

```rb
error 400, 'Bad Request'
```

but it returns `Content-Type` with `text/html`, not `text/plain`.

This PR fixes them with using `#halt`, instead of `#error`.

Thanks!