### PR TITLE
Remove ruby-head from travis config and add 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
-  - ruby-head
+  - 2.7
 before_install:
   - if [ ${TRAVIS_RUBY_VERSION} = '2.2' ]; then
       gem install bundler -v '< 2';


### PR DESCRIPTION
`ruby-head` is too new for us to use in CI.

```
$ ruby --version
ruby 2.8.0dev (2020-01-26T11:03:27Z master 838fa941f1) [x86_64-linux]
```