### PR TITLE
Add narrowcast method to client

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -179,6 +179,9 @@ module Line
 
       # Narrowcast messages to users
       #
+      # API Documentation is here.
+      # https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
+      #
       # @param messages [Hash or Array]
       # @param recipient [Hash]
       # @param filter [Hash]

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -177,6 +177,29 @@ module Line
         post(endpoint, endpoint_path, payload, credentials)
       end
 
+      # Narrowcast messages to users
+      #
+      # @param messages [Hash or Array]
+      # @param recipient [Hash]
+      # @param filter [Hash]
+      # @param limit [Hash]
+      #
+      # @return [Net::HTTPResponse]
+      def narrowcast(messages, recipient: nil, filter: nil, limit: nil)
+        channel_token_required
+
+        messages = [messages] if messages.is_a?(Hash)
+
+        endpoint_path = '/bot/message/narrowcast'
+        payload = {
+          messages: messages,
+          recipient: recipient,
+          filter: filter,
+          limit: limit
+        }.to_json
+        post(endpoint, endpoint_path, payload, credentials)
+      end
+
       def leave_group(group_id)
         channel_token_required
 

--- a/spec/line/bot/send_message_01_text_spec.rb
+++ b/spec/line/bot/send_message_01_text_spec.rb
@@ -135,14 +135,14 @@ describe Line::Bot::Client do
       text: 'Hello, world'
     }
     recipient = {
-      type: "audience",
+      type: 'audience',
       audienceGroupId: 5614991017776
     }
     filter = {
       demographic: {
-        type: "appType",
+        type: 'appType',
         oneOf: [
-          "android"
+          'android'
         ]
       }
     }

--- a/spec/line/bot/send_message_01_text_spec.rb
+++ b/spec/line/bot/send_message_01_text_spec.rb
@@ -98,4 +98,65 @@ describe Line::Bot::Client do
     }.to_json
     expect(response.body).to eq(expected)
   end
+
+  it 'narrowcast the text message without any conditions' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/narrowcast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    message = {
+      type: 'text',
+      text: 'Hello, world'
+    }
+    response = client.narrowcast(message)
+
+    expected = {
+      messages: [message],
+      recipient: nil,
+      filter: nil,
+      limit: nil
+    }.to_json
+    expect(response.body).to eq(expected)
+  end
+
+  it 'narrowcast the text message' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/narrowcast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    message = {
+      type: 'text',
+      text: 'Hello, world'
+    }
+    recipient = {
+      type: "audience",
+      audienceGroupId: 5614991017776
+    }
+    filter = {
+      demographic: {
+        type: "appType",
+        oneOf: [
+          "android"
+        ]
+      }
+    }
+    limit = {
+      max: 300
+    }
+    response = client.narrowcast(message, recipient: recipient, filter: filter, limit: limit)
+
+    expected = {
+      messages: [message],
+      recipient: recipient,
+      filter: filter,
+      limit: limit
+    }.to_json
+    expect(response.body).to eq(expected)
+  end
 end


### PR DESCRIPTION
NEW API to send targeted messages!!!
Closes https://github.com/line/line-bot-sdk-ruby/issues/161

API spec is here.
https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message

TODO: Check this API accepts null value for the parameters `recipient`, `filter`, `limit`.