### PR TITLE
Quit top level reference

### DIFF
--- a/lib/line/bot/api.rb
+++ b/lib/line/bot/api.rb
@@ -22,7 +22,7 @@ module Line
 
       DEFAULT_HEADERS = {
         'Content-Type' => 'application/json; charset=UTF-8',
-        'User-Agent'   => "LINE-BotSDK-Ruby/#{Line::Bot::API::VERSION}"
+        'User-Agent'   => "LINE-BotSDK-Ruby/#{VERSION}"
       }.freeze
     end
   end

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -48,18 +48,18 @@ module Line
       end
 
       def httpclient
-        @httpclient ||= Line::Bot::HTTPClient.new(http_options)
+        @httpclient ||= HTTPClient.new(http_options)
       end
 
       def endpoint
-        @endpoint ||= Line::Bot::API::DEFAULT_ENDPOINT
+        @endpoint ||= API::DEFAULT_ENDPOINT
       end
 
       def blob_endpoint
         return @blob_endpoint if @blob_endpoint
 
-        @blob_endpoint = if endpoint == Line::Bot::API::DEFAULT_ENDPOINT
-                           Line::Bot::API::DEFAULT_BLOB_ENDPOINT
+        @blob_endpoint = if endpoint == API::DEFAULT_ENDPOINT
+                           API::DEFAULT_BLOB_ENDPOINT
                          else
                            # for backward compatible
                            endpoint
@@ -605,7 +605,7 @@ module Line
       #
       # @return [Net::HTTPResponse]
       def get(endpoint_base, endpoint_path, headers = {})
-        headers = Line::Bot::API::DEFAULT_HEADERS.merge(headers)
+        headers = API::DEFAULT_HEADERS.merge(headers)
         httpclient.get(endpoint_base + endpoint_path, headers)
       end
 
@@ -618,7 +618,7 @@ module Line
       #
       # @return [Net::HTTPResponse]
       def post(endpoint_base, endpoint_path, payload = nil, headers = {})
-        headers = Line::Bot::API::DEFAULT_HEADERS.merge(headers)
+        headers = API::DEFAULT_HEADERS.merge(headers)
         httpclient.post(endpoint_base + endpoint_path, payload, headers)
       end
 
@@ -630,7 +630,7 @@ module Line
       #
       # @return [Net::HTTPResponse]
       def delete(endpoint_base, endpoint_path, headers = {})
-        headers = Line::Bot::API::DEFAULT_HEADERS.merge(headers)
+        headers = API::DEFAULT_HEADERS.merge(headers)
         httpclient.delete(endpoint_base + endpoint_path, headers)
       end
 
@@ -644,10 +644,10 @@ module Line
 
         json['events'].map do |item|
           begin
-            klass = Line::Bot::Event.const_get(Line::Bot::Util.camelize(item['type']))
+            klass = Event.const_get(Util.camelize(item['type']))
             klass.new(item)
           rescue NameError
-            Line::Bot::Event::Base.new(item)
+            Event::Base.new(item)
           end
         end
       end

--- a/lib/line/bot/event/message.rb
+++ b/lib/line/bot/event/message.rb
@@ -31,9 +31,9 @@ module Line
       # https://developers.line.biz/en/reference/messaging-api/#message-event
       class Message < Base
         def type
-          Line::Bot::Event::MessageType.const_get(@src['message']['type'].capitalize)
+          MessageType.const_get(@src['message']['type'].capitalize)
         rescue NameError => e
-          Line::Bot::Event::MessageType::Unsupport
+          MessageType::Unsupport
         end
 
         def message

--- a/lib/line/bot/event/things.rb
+++ b/lib/line/bot/event/things.rb
@@ -29,9 +29,9 @@ module Line
       # * https://developers.line.biz/en/reference/messaging-api/#scenario-result-event
       class Things < Base
         def type
-          Line::Bot::Event::ThingsType.const_get(Line::Bot::Util.camelize(@src['things']['type']))
+          ThingsType.const_get(Util.camelize(@src['things']['type']))
         rescue NameError
-          Line::Bot::Event::ThingsType::Unsupport
+          ThingsType::Unsupport
         end
 
         def device_id


### PR DESCRIPTION
Referencing from within a gem like `Line::Bot::XXXX`, it is difficult to rename and use the module.