### PR TITLE
Accept open-uri as create_rich_menu_image's argument

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -507,21 +507,8 @@ module Line
       def create_rich_menu_image(rich_menu_id, file)
         channel_token_required
 
-        content_type = if file.respond_to?(:content_type)
-                         content_type = file.content_type
-                         raise ArgumentError, "invalid content type: #{content_type}" unless ['image/jpeg', 'image/png'].include?(content_type)
-                         content_type
-                       else
-                         case file.path
-                         when /\.jpe?g\z/i then 'image/jpeg'
-                         when /\.png\z/i   then 'image/png'
-                         else
-                           raise ArgumentError, "invalid file extension: #{file.path}"
-                         end
-                       end
-
         endpoint_path = "/bot/richmenu/#{rich_menu_id}/content"
-        headers = credentials.merge('Content-Type' => content_type)
+        headers = credentials.merge('Content-Type' => content_type(file))
         post(blob_endpoint, endpoint_path, file.rewind && file.read, headers)
       end
 
@@ -695,6 +682,21 @@ module Line
         res = 0
         b.each_byte { |byte| res |= byte ^ l.shift }
         res == 0
+      end
+
+      def content_type(file)
+        if file.respond_to?(:content_type)
+          content_type = file.content_type
+          raise ArgumentError, "invalid content type: #{content_type}" unless ['image/jpeg', 'image/png'].include?(content_type)
+          content_type
+        else
+          case file.path
+          when /\.jpe?g\z/i then 'image/jpeg'
+          when /\.png\z/i   then 'image/png'
+          else
+            raise ArgumentError, "invalid file extension: #{file.path}"
+          end
+        end
       end
 
       def channel_token_required

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -507,11 +507,17 @@ module Line
       def create_rich_menu_image(rich_menu_id, file)
         channel_token_required
 
-        content_type = case file.path
-                       when /\.jpe?g\z/i then 'image/jpeg'
-                       when /\.png\z/i   then 'image/png'
+        content_type = if file.respond_to?(:content_type)
+                         content_type = file.content_type
+                         raise ArgumentError, "invalid content type: #{content_type}" unless ['image/jpeg', 'image/png'].include?(content_type)
+                         content_type
                        else
-                         raise ArgumentError, "invalid file extension: #{file.path}"
+                         case file.path
+                         when /\.jpe?g\z/i then 'image/jpeg'
+                         when /\.png\z/i   then 'image/png'
+                         else
+                           raise ArgumentError, "invalid file extension: #{file.path}"
+                         end
                        end
 
         endpoint_path = "/bot/richmenu/#{rich_menu_id}/content"

--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.11" if RUBY_VERSION < "2.3"
   spec.add_development_dependency 'rake', "~> 10.4"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 1.24"
+  spec.add_development_dependency "webmock", "~> 3.8"
 end

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 require 'tempfile'
+require 'open-uri'
 
 RICH_MENU_CONTENT = <<"EOS"
 {
@@ -177,6 +178,24 @@ describe Line::Bot::Client do
       .with(body: File.open(RICH_MENU_IMAGE_FILE_PATH).read)
   end
 
+  it 'uploads and attaches am image to a rich menu from uri' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_BLOB_ENDPOINT + '/bot/richmenu/1234567/content'
+
+    stub_request(:post, uri_template).to_return(body: '{}', status: 200).with do |request|
+      expect(request.headers["Content-Type"]).to eq('image/png')
+    end
+
+    image_url = 'https://line.example.org/rich_menu.png'
+    image_content = File.open(RICH_MENU_IMAGE_FILE_PATH).read
+    image_content.force_encoding('ASCII-8BIT')
+    stub_request(:get, image_url).to_return(body: image_content, status: 200, headers: {'Content-type': 'image/png' })
+
+    client.create_rich_menu_image('1234567', open(image_url))
+
+    expect(WebMock).to have_requested(:post, Line::Bot::API::DEFAULT_BLOB_ENDPOINT + '/bot/richmenu/1234567/content')
+      .with(body: image_content)
+  end
+
   it "uploads invalid extension's file" do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/1234567/content'
     stub_request(:post, uri_template).to_return(body: '{}', status: 200)
@@ -184,6 +203,19 @@ describe Line::Bot::Client do
       File.open(RICH_MENU_INVALID_FILE_EXTENSION_PATH) do |file|
         client.create_rich_menu_image('1234567', file)
       end
+    end.to raise_error(ArgumentError)
+  end
+
+  it "uploads invalid content type uri" do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/1234567/content'
+    stub_request(:post, uri_template).to_return(body: '{}', status: 200)
+
+    text_url = 'https://line.example.org/rich_menu.txt'
+    text_content = File.open(RICH_MENU_INVALID_FILE_EXTENSION_PATH).read
+    stub_request(:get, text_url).to_return(body: text_content, status: 200, headers: {'Content-type': 'plain/text' })
+
+    expect do
+      client.create_rich_menu_image('1234567', open(text_url))
     end.to raise_error(ArgumentError)
   end
 end

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -188,9 +188,9 @@ describe Line::Bot::Client do
     image_url = 'https://line.example.org/rich_menu.png'
     image_content = File.open(RICH_MENU_IMAGE_FILE_PATH).read
     image_content.force_encoding('ASCII-8BIT')
-    stub_request(:get, image_url).to_return(body: image_content, status: 200, headers: {'Content-type': 'image/png' })
+    stub_request(:get, image_url).to_return(body: image_content, status: 200, headers: { 'Content-type' => 'image/png' })
 
-    client.create_rich_menu_image('1234567', open(image_url))
+    client.create_rich_menu_image('1234567', URI.parse(image_url).open)
 
     expect(WebMock).to have_requested(:post, Line::Bot::API::DEFAULT_BLOB_ENDPOINT + '/bot/richmenu/1234567/content')
       .with(body: image_content)
@@ -212,10 +212,10 @@ describe Line::Bot::Client do
 
     text_url = 'https://line.example.org/rich_menu.txt'
     text_content = File.open(RICH_MENU_INVALID_FILE_EXTENSION_PATH).read
-    stub_request(:get, text_url).to_return(body: text_content, status: 200, headers: {'Content-type': 'plain/text' })
+    stub_request(:get, text_url).to_return(body: text_content, status: 200, headers: { 'Content-type' => 'plain/text' })
 
     expect do
-      client.create_rich_menu_image('1234567', open(text_url))
+      client.create_rich_menu_image('1234567', URI.parse(text_url).open)
     end.to raise_error(ArgumentError)
   end
 end

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -178,7 +178,7 @@ describe Line::Bot::Client do
       .with(body: File.open(RICH_MENU_IMAGE_FILE_PATH).read)
   end
 
-  it 'uploads and attaches am image to a rich menu from uri' do
+  it 'uploads and attaches an image to a rich menu from uri' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_BLOB_ENDPOINT + '/bot/richmenu/1234567/content'
 
     stub_request(:post, uri_template).to_return(body: '{}', status: 200).with do |request|
@@ -188,7 +188,7 @@ describe Line::Bot::Client do
     image_url = 'https://line.example.org/rich_menu.png'
     image_content = File.open(RICH_MENU_IMAGE_FILE_PATH).read
     image_content.force_encoding('ASCII-8BIT')
-    stub_request(:get, image_url).to_return(body: image_content, status: 200, headers: { 'Content-type' => 'image/png' })
+    stub_request(:get, image_url).to_return(body: image_content, status: 200, headers: { 'Content-Type' => 'image/png' })
 
     client.create_rich_menu_image('1234567', URI.parse(image_url).open)
 
@@ -206,13 +206,13 @@ describe Line::Bot::Client do
     end.to raise_error(ArgumentError)
   end
 
-  it "uploads invalid content type uri" do
+  it 'uploads invalid content type uri' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/1234567/content'
     stub_request(:post, uri_template).to_return(body: '{}', status: 200)
 
     text_url = 'https://line.example.org/rich_menu.txt'
     text_content = File.open(RICH_MENU_INVALID_FILE_EXTENSION_PATH).read
-    stub_request(:get, text_url).to_return(body: text_content, status: 200, headers: { 'Content-type' => 'plain/text' })
+    stub_request(:get, text_url).to_return(body: text_content, status: 200, headers: { 'Content-Type' => 'plain/text' })
 
     expect do
       client.create_rich_menu_image('1234567', URI.parse(text_url).open)


### PR DESCRIPTION
Passing `open(uri)` to `create_rich_menu` fails because content type detection is based on file name extension.
Tempfile returned by open-uri is equipped with 'content_type', so let's use this to fix it.

Upgrading webmock was required to fix behavior of mocked `open(uri)`.