### PR TITLE
Use ENV for default credentials

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -34,11 +34,13 @@ module Line
       #
       # @param options [Hash]
       # @return [Line::Bot::Client]
-      def initialize(options = { channel_token: ENV["LINE_CHANNEL_TOKEN"],
-                                 channel_id: ENV["LINE_CHANNEL_ID"],
-                                 channel_secret: ENV["LINE_CHANNEL_SECRET"] })
+      def initialize(options = {})
         options.each do |key, value|
           instance_variable_set("@#{key}", value)
+        end
+        %w[channel_token channel_id channel_secret].each do |key|
+          value = ENV["LINE_#{key.upcase}"]
+          instance_variable_set("@#{key}", value) if value
         end
         yield(self) if block_given?
       end

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -20,12 +20,6 @@ require 'uri'
 module Line
   module Bot
     # API Client of LINE Bot SDK Ruby
-    #
-    #   @client ||= Line::Bot::Client.new do |config|
-    #     config.channel_id = ENV["LINE_CHANNEL_ID"]
-    #     config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-    #     config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
-    #   end
     class Client
       #  @return [String]
       attr_accessor :channel_token, :channel_id, :channel_secret, :endpoint, :blob_endpoint
@@ -40,7 +34,9 @@ module Line
       #
       # @param options [Hash]
       # @return [Line::Bot::Client]
-      def initialize(options = {})
+      def initialize(options = { channel_token: ENV["LINE_CHANNEL_TOKEN"],
+                                 channel_id: ENV["LINE_CHANNEL_ID"],
+                                 channel_secret: ENV["LINE_CHANNEL_SECRET"] })
         options.each do |key, value|
           instance_variable_set("@#{key}", value)
         end

--- a/spec/line/bot/client_spec.rb
+++ b/spec/line/bot/client_spec.rb
@@ -126,4 +126,15 @@ describe Line::Bot::Client do
     messages = body[:messages]
     expect(messages[0]).to eq message
   end
+
+  it 'reads credentials from ENV' do
+    ENV['LINE_CHANNEL_ID'] = 'CHANNEL_ID'
+    ENV['LINE_CHANNEL_SECRET'] = 'CHANNEL_SECRET'
+    ENV['LINE_CHANNEL_TOKEN'] = 'CHANNEL_TOKEN'
+
+    client = Line::Bot::Client.new
+    expect(client.channel_id).to eq 'CHANNEL_ID'
+    expect(client.channel_secret).to eq 'CHANNEL_SECRET'
+    expect(client.channel_token).to eq 'CHANNEL_TOKEN'
+  end
 end


### PR DESCRIPTION
As putting credentials in ENV is considered best practices, let's make it as default arguments for this client.