### PR TITLE
Add audience API endpoints

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -688,6 +688,21 @@ module Line
         post(endpoint, endpoint_path, params.to_json, credentials)
       end
 
+      # Update an audience group
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#update-upload-audience-group
+      #
+      # @param opts [Hash] options
+      #
+      # @return [Net::HTTPResponse] This response includes an audience_group_id.
+      def update_user_id_audience(params)
+        channel_token_required
+
+        endpoint_path = '/bot/audienceGroup/upload'
+        put(endpoint, endpoint_path, params.to_json, credentials)
+      end
+
       # Create an audience group of users that clicked a URL in a message sent in the past
       #
       # Parameters are described here.
@@ -727,12 +742,15 @@ module Line
       def rename_audience(audience_group_id, description)
         channel_token_required
 
-        endpoint_path = "/bot/audienceGroup/#{audience_group_id}"
+        endpoint_path = "/bot/audienceGroup/#{audience_group_id}/updateDescription"
         body = {description: description}
         put(endpoint, endpoint_path, body.to_json, credentials)
       end
 
       # Delete an existing audience group
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#delete-audience-group
       #
       # @param audience_group_id [Integer]
       #
@@ -745,6 +763,9 @@ module Line
       end
 
       # Get audience group data
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#get-audience-group
       #
       # @param audience_group_id [Integer]
       #
@@ -761,17 +782,20 @@ module Line
       # Parameters are described here.
       # https://developers.line.biz/en/reference/messaging-api/#get-audience-groups
       #
-      # @param params [Hash] key name `size` is required
+      # @param params [Hash] key name `page` is required
       #
       # @return [Net::HTTPResponse]
       def get_audiences(params)
         channel_token_required
 
-        endpoint_path = "/bot/audienceGroup/list?" + params.map{|k, v| "#{k}=#{v}"}.join('&')
+        endpoint_path = "/bot/audienceGroup/list?" + URI.encode_www_form(params)
         get(endpoint, endpoint_path, credentials)
       end
 
       # Get the authority level of the audience
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#get-authority-level
       #
       # @return [Net::HTTPResponse]
       def get_audience_authority_level
@@ -782,6 +806,9 @@ module Line
       end
 
       # Change the authority level of the audience
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#change-authority-level
       #
       # @param authority_level [String] value must be `PUBLIC` or `PRIVATE`
       #

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -726,7 +726,7 @@ module Line
       # @param opts [Hash] options
       #
       # @return [Net::HTTPResponse] This response includes an audience_group_id.
-      def create_impression_audience
+      def create_impression_audience(params)
         channel_token_required
 
         endpoint_path = '/bot/audienceGroup/imp'

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -678,7 +678,7 @@ module Line
       # Parameters are described here.
       # https://developers.line.biz/en/reference/messaging-api/#create-upload-audience-group
       #
-      # @param opts [Hash] options
+      # @param params [Hash] options
       #
       # @return [Net::HTTPResponse] This response includes an audience_group_id.
       def create_user_id_audience(params)
@@ -693,7 +693,7 @@ module Line
       # Parameters are described here.
       # https://developers.line.biz/en/reference/messaging-api/#update-upload-audience-group
       #
-      # @param opts [Hash] options
+      # @param params [Hash] options
       #
       # @return [Net::HTTPResponse] This response includes an audience_group_id.
       def update_user_id_audience(params)
@@ -708,7 +708,7 @@ module Line
       # Parameters are described here.
       # https://developers.line.biz/en/reference/messaging-api/#create-click-audience-group
       #
-      # @param opts [Hash] options
+      # @param params [Hash] options
       #
       # @return [Net::HTTPResponse] This response includes an audience_group_id.
       def create_click_audience(params)
@@ -723,7 +723,7 @@ module Line
       # Parameters are described here.
       # https://developers.line.biz/en/reference/messaging-api/#create-imp-audience-group
       #
-      # @param opts [Hash] options
+      # @param params [Hash] options
       #
       # @return [Net::HTTPResponse] This response includes an audience_group_id.
       def create_impression_audience(params)

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -673,6 +673,127 @@ module Line
         delete(liff_endpoint, endpoint_path, credentials)
       end
 
+      # Create an audience group by uploading user_ids
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#create-upload-audience-group
+      #
+      # @param opts [Hash] options
+      #
+      # @return [Net::HTTPResponse] This response includes an audience_group_id.
+      def create_user_id_audience(params)
+        channel_token_required
+
+        endpoint_path = '/bot/audienceGroup/upload'
+        post(endpoint, endpoint_path, params.to_json, credentials)
+      end
+
+      # Create an audience group of users that clicked a URL in a message sent in the past
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#create-click-audience-group
+      #
+      # @param opts [Hash] options
+      #
+      # @return [Net::HTTPResponse] This response includes an audience_group_id.
+      def create_click_audience(params)
+        channel_token_required
+
+        endpoint_path = '/bot/audienceGroup/click'
+        post(endpoint, endpoint_path, params.to_json, credentials)
+      end
+
+      # Create an audience group of users that opened a message sent in the past
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#create-imp-audience-group
+      #
+      # @param opts [Hash] options
+      #
+      # @return [Net::HTTPResponse] This response includes an audience_group_id.
+      def create_impression_audience
+        channel_token_required
+
+        endpoint_path = '/bot/audienceGroup/imp'
+        post(endpoint, endpoint_path, params.to_json, credentials)
+      end
+
+      # Rename an existing audience group
+      #
+      # @param audience_group_id [Integer]
+      # @param description [String]
+      #
+      # @return [Net::HTTPResponse]
+      def rename_audience(audience_group_id, description)
+        channel_token_required
+
+        endpoint_path = "/bot/audienceGroup/#{audience_group_id}"
+        body = {description: description}
+        put(endpoint, endpoint_path, body.to_json, credentials)
+      end
+
+      # Delete an existing audience group
+      #
+      # @param audience_group_id [Integer]
+      #
+      # @return [Net::HTTPResponse]
+      def delete_audience(audience_group_id)
+        channel_token_required
+
+        endpoint_path = "/bot/audienceGroup/#{audience_group_id}"
+        delete(endpoint, endpoint_path, credentials)
+      end
+
+      # Get audience group data
+      #
+      # @param audience_group_id [Integer]
+      #
+      # @return [Net::HTTPResponse]
+      def get_audience(audience_group_id)
+        channel_token_required
+
+        endpoint_path = "/bot/audienceGroup/#{audience_group_id}"
+        get(endpoint, endpoint_path, credentials)
+      end
+
+      # Get data for more than one audience group
+      #
+      # Parameters are described here.
+      # https://developers.line.biz/en/reference/messaging-api/#get-audience-groups
+      #
+      # @param params [Hash] key name `size` is required
+      #
+      # @return [Net::HTTPResponse]
+      def get_audiences(params)
+        channel_token_required
+
+        endpoint_path = "/bot/audienceGroup/list?" + params.map{|k, v| "#{k}=#{v}"}.join('&')
+        get(endpoint, endpoint_path, credentials)
+      end
+
+      # Get the authority level of the audience
+      #
+      # @return [Net::HTTPResponse]
+      def get_audience_authority_level
+        channel_token_required
+
+        endpoint_path = "/bot/audienceGroup/authorityLevel"
+        get(endpoint, endpoint_path, credentials)
+      end
+
+      # Change the authority level of the audience
+      #
+      # @param authority_level [String] value must be `PUBLIC` or `PRIVATE`
+      #
+      # @return [Net::HTTPResponse]
+      def update_audience_authority_level(authority_level)
+        channel_token_required
+
+        endpoint_path = "/bot/audienceGroup/authorityLevel"
+        body = {authorityLevel: authority_level}
+        put(endpoint, endpoint_path, body.to_json, credentials)
+      end
+
       # Fetch data, get content of specified URL.
       #
       # @param endpoint_base [String]

--- a/spec/line/bot/client_audience_spec.rb
+++ b/spec/line/bot/client_audience_spec.rb
@@ -1,0 +1,136 @@
+require 'spec_helper'
+require 'json'
+require_relative 'mock_http_client'
+
+describe Line::Bot::Client do
+  def generate_client
+    Line::Bot::Client.new do |config|
+      config.channel_id = '1234567'
+      config.channel_token = 'channelToken'
+      config.channel_secret = 'channelSecret'
+      config.httpclient = MockHTTPClient.new
+    end
+  end
+
+  it 'execute create_user_id_audience' do
+    payload = {
+      description: 'create_user_id_audience 1',
+      audiences: [{id: 'u123abc'}]
+    }
+
+    response = generate_client.create_user_id_audience(payload)
+
+    expect(response).to eq(
+      method: :post,
+      url: 'https://api.line.me/v2/bot/audienceGroup/upload',
+      payload: payload.to_json
+    )
+  end
+
+  it 'execute update_user_id_audience' do
+    payload = {
+      audienceGroupId: 123,
+      description: 'audience 1',
+      audiences: [{id: 'u123abc'}]
+    }
+
+    response = generate_client.update_user_id_audience(payload)
+
+    expect(response).to eq(
+      method: :put,
+      url: 'https://api.line.me/v2/bot/audienceGroup/upload',
+      payload: payload.to_json
+    )
+  end
+
+  it 'execute create_click_audience' do
+    payload = {
+      description: 'audience 2',
+      requestId: 'a523d8b2-4728-4ac5-ad4f-b176afd43267'
+    }
+
+    response = generate_client.create_click_audience(payload)
+
+    expect(response).to eq(
+      method: :post,
+      url: 'https://api.line.me/v2/bot/audienceGroup/click',
+      payload: payload.to_json
+    )
+  end
+
+  it 'execute create_impression_audience' do
+    payload = {
+      description: 'audience 3',
+      requestId: 'a523d8b2-4728-4ac5-ad4f-b176afd43267'
+    }
+
+    response = generate_client.create_impression_audience(payload)
+
+    expect(response).to eq(
+      method: :post,
+      url: 'https://api.line.me/v2/bot/audienceGroup/imp',
+      payload: payload.to_json
+    )
+  end
+
+  it 'execute rename_audience' do
+    response = generate_client.rename_audience(123, 'audience 10')
+
+    expect(response).to eq(
+      method: :put,
+      url: 'https://api.line.me/v2/bot/audienceGroup/123/updateDescription',
+      payload: {description: 'audience 10'}.to_json
+    )
+  end
+
+  it 'execute delete_audience' do
+    response = generate_client.delete_audience(123)
+
+    expect(response).to eq(
+      method: :delete,
+      url: 'https://api.line.me/v2/bot/audienceGroup/123',
+      payload: nil
+    )
+  end
+
+  it 'execute get_audience' do
+    response = generate_client.get_audience(123)
+
+    expect(response).to eq(
+      method: :get,
+      url: 'https://api.line.me/v2/bot/audienceGroup/123',
+      payload: nil
+    )
+  end
+
+  it 'execute get_audiences' do
+    params = {page: 2, status: 'READY'}
+    response = generate_client.get_audiences(params)
+
+    expect(response).to eq(
+      method: :get,
+      url: 'https://api.line.me/v2/bot/audienceGroup/list?page=2&status=READY',
+      payload: nil
+    )
+  end
+
+  it 'execute get_audience_authority_level' do
+    response = generate_client.get_audience_authority_level
+
+    expect(response).to eq(
+      method: :get,
+      url: 'https://api.line.me/v2/bot/audienceGroup/authorityLevel',
+      payload: nil
+    )
+  end
+
+  it 'execute update_audience_authority_level' do
+    response = generate_client.update_audience_authority_level('PRIVATE')
+
+    expect(response).to eq(
+      method: :put,
+      url: 'https://api.line.me/v2/bot/audienceGroup/authorityLevel',
+      payload: {authorityLevel: 'PRIVATE'}.to_json
+    )
+  end
+end

--- a/spec/line/bot/mock_http_client.rb
+++ b/spec/line/bot/mock_http_client.rb
@@ -1,0 +1,27 @@
+class MockHTTPClient
+  def get(url, _header = {})
+    build_mock_response(:get, url, nil)
+  end
+
+  def post(url, payload, _header = {})
+    build_mock_response(:post, url, payload)
+  end
+
+  def put(url, payload, _header = {})
+    build_mock_response(:put, url, payload)
+  end
+
+  def delete(url, _header = {})
+    build_mock_response(:delete, url, nil)
+  end
+
+  private
+
+  def build_mock_response(method, url, payload)
+    {
+      method: method,
+      url: url,
+      payload: payload
+    }
+  end
+end


### PR DESCRIPTION
Resolve https://github.com/line/line-bot-sdk-ruby/issues/172

This pull request adds methods corresponding to the newly added audience API.

The audience API is described here.
https://developers.line.biz/en/docs/messaging-api/using-audience/

This pull request includes 9 methods.

TODO: Check if this code works well