### PR TITLE
Support LIFF v1 Server API

### DIFF
--- a/lib/line/bot/api.rb
+++ b/lib/line/bot/api.rb
@@ -19,6 +19,7 @@ module Line
     module API
       DEFAULT_ENDPOINT = "https://api.line.me/v2"
       DEFAULT_BLOB_ENDPOINT = "https://api-data.line.me/v2"
+      DEFAULT_LIFF_ENDPOINT = "https://api.line.me/liff/v1"
 
       DEFAULT_HEADERS = {
         'Content-Type' => 'application/json; charset=UTF-8',

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -66,6 +66,10 @@ module Line
                          end
       end
 
+      def liff_endpoint
+        @liff_endpoint ||= endpoint.sub(%r{/v2\z}, '')
+      end
+
       # @return [Hash]
       def credentials
         {
@@ -641,6 +645,34 @@ module Line
         get(endpoint, endpoint_path, credentials)
       end
 
+      def get_liff_apps
+        channel_token_required
+
+        endpoint_path = '/liff/v1/apps'
+        get(liff_endpoint, endpoint_path, credentials)
+      end
+
+      def create_liff_app(app)
+        channel_token_required
+
+        endpoint_path = '/liff/v1/apps'
+        post(liff_endpoint, endpoint_path, app.to_json, credentials)
+      end
+
+      def update_liff_app(liff_id, app)
+        channel_token_required
+
+        endpoint_path = "/liff/v1/apps/#{liff_id}"
+        put(liff_endpoint, endpoint_path, app.to_json, credentials)
+      end
+
+      def delete_liff_app(liff_id)
+        channel_token_required
+
+        endpoint_path = "/liff/v1/apps/#{liff_id}"
+        delete(liff_endpoint, endpoint_path, credentials)
+      end
+
       # Fetch data, get content of specified URL.
       #
       # @param endpoint_base [String]
@@ -664,6 +696,19 @@ module Line
       def post(endpoint_base, endpoint_path, payload = nil, headers = {})
         headers = API::DEFAULT_HEADERS.merge(headers)
         httpclient.post(endpoint_base + endpoint_path, payload, headers)
+      end
+
+      # Put data, get content of specified URL.
+      #
+      # @param endpoint_base [String]
+      # @param endpoint_path [String]
+      # @param payload [String or NilClass]
+      # @param headers [Hash]
+      #
+      # @return [Net::HTTPResponse]
+      def put(endpoint_base, endpoint_path, payload = nil, headers = {})
+        headers = API::DEFAULT_HEADERS.merge(headers)
+        httpclient.put(endpoint_base + endpoint_path, payload, headers)
       end
 
       # Delete content of specified URL.

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -67,7 +67,7 @@ module Line
       end
 
       def liff_endpoint
-        @liff_endpoint ||= endpoint.sub(%r{/v2\z}, '')
+        @liff_endpoint ||= API::DEFAULT_LIFF_ENDPOINT
       end
 
       # @return [Hash]
@@ -648,28 +648,28 @@ module Line
       def get_liff_apps
         channel_token_required
 
-        endpoint_path = '/liff/v1/apps'
+        endpoint_path = '/apps'
         get(liff_endpoint, endpoint_path, credentials)
       end
 
       def create_liff_app(app)
         channel_token_required
 
-        endpoint_path = '/liff/v1/apps'
+        endpoint_path = '/apps'
         post(liff_endpoint, endpoint_path, app.to_json, credentials)
       end
 
       def update_liff_app(liff_id, app)
         channel_token_required
 
-        endpoint_path = "/liff/v1/apps/#{liff_id}"
+        endpoint_path = "/apps/#{liff_id}"
         put(liff_endpoint, endpoint_path, app.to_json, credentials)
       end
 
       def delete_liff_app(liff_id)
         channel_token_required
 
-        endpoint_path = "/liff/v1/apps/#{liff_id}"
+        endpoint_path = "/apps/#{liff_id}"
         delete(liff_endpoint, endpoint_path, credentials)
       end
 

--- a/lib/line/bot/httpclient.rb
+++ b/lib/line/bot/httpclient.rb
@@ -57,6 +57,11 @@ module Line
         http(uri).post(uri.request_uri, payload, header)
       end
 
+      def put(url, payload, header = {})
+        uri = URI(url)
+        http(uri).put(uri.request_uri, payload, header)
+      end
+
       def delete(url, header = {})
         uri = URI(url)
         http(uri).delete(uri.request_uri, header)

--- a/spec/line/bot/liff_spec.rb
+++ b/spec/line/bot/liff_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'json'
+
+LIFF_APP_CONTENT = <<LIFF
+{
+  "liffId": "1234567-abcdefgh",
+  "view": {
+    "type": "full",
+    "url": "https://example.com/myservice"
+  },
+  "description": "Happy New York",
+  "permanentLinkPattern": "concat"
+}
+LIFF
+LIFF_APP_LIST_CONTENT = <<LIFF
+{
+    "apps": [
+    #{LIFF_APP_CONTENT}
+    ]
+}
+LIFF
+
+LIFF_ENDPOINT = 'https://api.line.me'
+
+describe Line::Bot::Client do
+  let(:client) do
+    dummy_config = {
+      channel_token: 'access token',
+    }
+    Line::Bot::Client.new do |config|
+      config.channel_token = dummy_config[:channel_token]
+    end
+  end
+
+  it 'gets a list of liff apps' do
+    uri_template = Addressable::Template.new LIFF_ENDPOINT + '/liff/v1/apps'
+    stub_request(:get, uri_template).to_return(body: LIFF_APP_LIST_CONTENT, status: 200)
+
+    response = client.get_liff_apps
+    expect(WebMock).to have_requested(:get, LIFF_ENDPOINT + '/liff/v1/apps')
+    expect(response.body).to eq LIFF_APP_LIST_CONTENT
+  end
+
+  it 'updates a liff app' do
+    uri_template = Addressable::Template.new LIFF_ENDPOINT + '/liff/v1/apps/1234567-abcdefgh'
+    stub_request(:put, uri_template).to_return(body: LIFF_APP_CONTENT, status: 200)
+
+    response = client.update_liff_app('1234567-abcdefgh', JSON.parse(LIFF_APP_CONTENT))
+    expect(WebMock).to have_requested(:put, LIFF_ENDPOINT + '/liff/v1/apps/1234567-abcdefgh')
+    .with(body: JSON.parse(LIFF_APP_CONTENT).to_json)
+    expect(response.body).to eq LIFF_APP_CONTENT
+  end
+
+  it 'creates a liff app' do
+    uri_template = Addressable::Template.new LIFF_ENDPOINT + '/liff/v1/apps'
+    stub_request(:post, uri_template).to_return(body: LIFF_APP_CONTENT, status: 200)
+
+    client.create_liff_app(JSON.parse(LIFF_APP_CONTENT))
+    expect(WebMock).to have_requested(:post, LIFF_ENDPOINT + '/liff/v1/apps')
+      .with(body: JSON.parse(LIFF_APP_CONTENT).to_json)
+  end
+
+  it 'deletes a liff app' do
+    uri_template = Addressable::Template.new LIFF_ENDPOINT + '/liff/v1/apps/1234567-abcdefgh'
+    stub_request(:delete, uri_template).to_return(body: '{}', status: 200)
+
+    client.delete_liff_app('1234567-abcdefgh')
+    expect(WebMock).to have_requested(:delete, LIFF_ENDPOINT + '/liff/v1/apps/1234567-abcdefgh')
+  end
+end

--- a/spec/line/bot/liff_spec.rb
+++ b/spec/line/bot/liff_spec.rb
@@ -48,7 +48,7 @@ describe Line::Bot::Client do
 
     response = client.update_liff_app('1234567-abcdefgh', JSON.parse(LIFF_APP_CONTENT))
     expect(WebMock).to have_requested(:put, LIFF_ENDPOINT + '/liff/v1/apps/1234567-abcdefgh')
-    .with(body: JSON.parse(LIFF_APP_CONTENT).to_json)
+      .with(body: JSON.parse(LIFF_APP_CONTENT).to_json)
     expect(response.body).to eq LIFF_APP_CONTENT
   end
 


### PR DESCRIPTION
[LIFF v1 Server API](https://developers.line.biz/en/reference/liff-v1/#server-api) is once [announced for removal](https://developers.line.biz/en/news/2020/01/21/liff-server-api-deprecation/), but it is [cancelled](https://developers.line.biz/en/news/2020/02/07/liff-server-api-update/).

Please support LIFF v1 Server API since LIFF v2 API does not provide Server API and there is no alternate way to access LIFF programatically.