### PR TITLE
disallow actual net connection during unit test

### DIFF
--- a/spec/line/bot/client_channel_token_spec.rb
+++ b/spec/line/bot/client_channel_token_spec.rb
@@ -10,8 +10,6 @@ OAUTH_CHANNEL_TOKEN_ISSUE_CONTENT = <<"EOS"
 }
 EOS
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   def dummy_config
     {

--- a/spec/line/bot/client_get_group_or_room_member_spec.rb
+++ b/spec/line/bot/client_get_group_or_room_member_spec.rb
@@ -51,8 +51,6 @@ ROOM_MEMBERS_COUNT = <<"EOS"
 }
 EOS
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   before do
   end

--- a/spec/line/bot/client_get_spec.rb
+++ b/spec/line/bot/client_get_spec.rb
@@ -200,8 +200,6 @@ BOT_INFO_CONTENT = <<"EOS"
 }
 EOS
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   before do
   end

--- a/spec/line/bot/client_spec.rb
+++ b/spec/line/bot/client_spec.rb
@@ -18,8 +18,6 @@ class TestClient
   end
 end
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   def dummy_config
     {

--- a/spec/line/bot/link_token_spec.rb
+++ b/spec/line/bot/link_token_spec.rb
@@ -8,8 +8,6 @@ LINK_TOKEN_CONTENT = <<"EOS"
 }
 EOS
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   let(:client) do
     dummy_config = {

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -41,8 +41,6 @@ EOS
 RICH_MENU_IMAGE_FILE_PATH = 'spec/fixtures/line/bot/rich_menu_01.png'
 RICH_MENU_INVALID_FILE_EXTENSION_PATH = 'spec/fixtures/line/bot/rich_menu_01.txt'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   let(:client) do
     dummy_config = {

--- a/spec/line/bot/send_message_01_text_spec.rb
+++ b/spec/line/bot/send_message_01_text_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the text message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_02_image_spec.rb
+++ b/spec/line/bot/send_message_02_image_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the image message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_03_video_spec.rb
+++ b/spec/line/bot/send_message_03_video_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the video message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_04_audio_spec.rb
+++ b/spec/line/bot/send_message_04_audio_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the audio message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_05_location_spec.rb
+++ b/spec/line/bot/send_message_05_location_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the location message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_06_sticker_spec.rb
+++ b/spec/line/bot/send_message_06_sticker_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the sticker message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_07_imagemap_spec.rb
+++ b/spec/line/bot/send_message_07_imagemap_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the imagemap message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_08_image_carousel_spec.rb
+++ b/spec/line/bot/send_message_08_image_carousel_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the image carousel message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_11_template_buttons_spec.rb
+++ b/spec/line/bot/send_message_11_template_buttons_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the template message type buttons' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_12_template_confirm_spec.rb
+++ b/spec/line/bot/send_message_12_template_confirm_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the template message type confirm' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_13_template_carousel_spec.rb
+++ b/spec/line/bot/send_message_13_template_carousel_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the template message type carousel' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'

--- a/spec/line/bot/send_message_14_template_datepicker_spec.rb
+++ b/spec/line/bot/send_message_14_template_datepicker_spec.rb
@@ -2,8 +2,6 @@ require 'spec_helper'
 require 'webmock/rspec'
 require 'json'
 
-WebMock.allow_net_connect!
-
 describe Line::Bot::Client do
   it 'pushes the template message type datepicker' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'


### PR DESCRIPTION
There is no need to allow real net connection since all HTTP requests are mocked.

While working  with #205, disabling real net connection helps me to notice making wrong request.
This may improve quality of unit test.