### PR TITLE
Add ruby v3.0 for pull request CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,11 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
     name: Ruby v${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
     - run: gem install bundler


### PR DESCRIPTION
Ruby v3.0 is released 🎉 

I'd like to use it for our pull request test.

In order to use ruby v3.0 in GitHub Actions,
it seems we should use `ruby/setup-ruby@v1`, instead of use `actions/setup-ruby@v1`.
https://github.com/actions/setup-ruby/issues/80
