### PR TITLE
Support follower IDs API

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -274,6 +274,20 @@ module Line
         get(endpoint, endpoint_path, credentials)
       end
 
+      # Get user IDs of who added your LINE Official Account as a friend
+      #
+      # @param continuation_token [String] Identifier to return next page
+      #                                   (next property to be included in the response)
+      #
+      # @return [Net::HTTPResponse]
+      def get_follower_ids(continuation_token = nil)
+        channel_token_required
+
+        endpoint_path = "/bot/followers/ids"
+        endpoint_path += "?start=#{continuation_token}" if continuation_token
+        get(endpoint, endpoint_path, credentials)
+      end
+
       # Get user IDs of a group
       #
       # @param group_id [String] Group's identifier

--- a/spec/line/bot/client_get_follower_spec.rb
+++ b/spec/line/bot/client_get_follower_spec.rb
@@ -24,9 +24,6 @@ NEXT_USER_ID_CONTENT = <<"EOS"
 EOS
 
 describe Line::Bot::Client do
-  before do
-  end
-
   def dummy_config
     {
       channel_token: 'access token',

--- a/spec/line/bot/client_get_follower_spec.rb
+++ b/spec/line/bot/client_get_follower_spec.rb
@@ -1,0 +1,69 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'json'
+
+USER_ID_CONTENT = <<"EOS"
+{
+    "userIds": [
+        "Uxxxxxxxxxxxxxx1",
+        "Uxxxxxxxxxxxxxx2",
+        "Uxxxxxxxxxxxxxx3"
+    ],
+    "next": "jxEWCEEP"
+}
+EOS
+
+NEXT_USER_ID_CONTENT = <<"EOS"
+{
+    "userIds": [
+        "Uxxxxxxxxxxxxxx4",
+        "Uxxxxxxxxxxxxxx5",
+        "Uxxxxxxxxxxxxxx6"
+    ]
+}
+EOS
+
+describe Line::Bot::Client do
+  before do
+  end
+
+  def dummy_config
+    {
+      channel_token: 'access token',
+    }
+  end
+
+  def generate_client
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = dummy_config[:channel_token]
+    end
+
+    client
+  end
+
+  it 'gets follower ids' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/followers/ids'
+    stub_request(:get, uri_template).to_return { |request| {body: USER_ID_CONTENT, status: 200} }
+
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/followers/ids?start={continuationToken}'
+    stub_request(:get, uri_template).to_return { |request| {body: NEXT_USER_ID_CONTENT, status: 200} }
+
+    client = generate_client
+
+    # first page
+    response = client.get_follower_ids
+
+    expect(response).to be_a(Net::HTTPOK)
+    result = JSON.parse(response.body)
+    expect(result['userIds']).to eq ["Uxxxxxxxxxxxxxx1", "Uxxxxxxxxxxxxxx2", "Uxxxxxxxxxxxxxx3"]
+    expect(result['next']).to eq "jxEWCEEP"
+
+    # second page
+    response = client.get_follower_ids(result['next'])
+
+    expect(response).to be_a(Net::HTTPOK)
+    result = JSON.parse(response.body)
+    expect(result['userIds']).to eq ["Uxxxxxxxxxxxxxx4", "Uxxxxxxxxxxxxxx5", "Uxxxxxxxxxxxxxx6"]
+    expect(result['next']).to be nil
+  end
+end


### PR DESCRIPTION
Add support for get follower IDs API.

- [Get a list of users who added your LINE Official Account as a friend](https://developers.line.biz/en/reference/messaging-api/#get-follower-ids)

refs: https://github.com/line/line-bot-sdk-ruby/issues/216