### PR TITLE
Remove unneeded before block

### DIFF
--- a/spec/line/bot/client_get_group_or_room_member_spec.rb
+++ b/spec/line/bot/client_get_group_or_room_member_spec.rb
@@ -52,9 +52,6 @@ ROOM_MEMBERS_COUNT = <<"EOS"
 EOS
 
 describe Line::Bot::Client do
-  before do
-  end
-
   def dummy_config
     {
       channel_token: 'access token',

--- a/spec/line/bot/client_get_spec.rb
+++ b/spec/line/bot/client_get_spec.rb
@@ -201,9 +201,6 @@ BOT_INFO_CONTENT = <<"EOS"
 EOS
 
 describe Line::Bot::Client do
-  before do
-  end
-
   def dummy_config
     {
       channel_token: 'access token',

--- a/spec/line/bot/client_parse_spec.rb
+++ b/spec/line/bot/client_parse_spec.rb
@@ -342,9 +342,6 @@ UNSUPPORT_MESSAGE_EVENT_CONTENT = <<"EOS"
 EOS
 
 describe Line::Bot::Client do
-  before do
-  end
-
   def dummy_config
     {
       channel_token: 'access token',


### PR DESCRIPTION
- Remove unneeded `before` block

Refs: https://github.com/line/line-bot-sdk-ruby/pull/217#pullrequestreview-594982623