### PR TITLE
[proposal] Make src accessible from event object

### DIFF
--- a/lib/line/bot/event/base.rb
+++ b/lib/line/bot/event/base.rb
@@ -19,6 +19,7 @@ module Line
         def initialize(src)
           @src = src
         end
+        attr_reader :src
 
         def [](key)
           @src[key]

--- a/lib/line/bot/event/base.rb
+++ b/lib/line/bot/event/base.rb
@@ -19,10 +19,13 @@ module Line
         def initialize(src)
           @src = src
         end
-        attr_reader :src
 
         def [](key)
           @src[key]
+        end
+
+        def to_hash
+          @src
         end
       end
     end


### PR DESCRIPTION
Sometimes, when using this sdk, I'd like to access the raw source event hash from application.
One application of such is to write serialization logic (on the application side) of the event objects.

With this PR, user can simply call `src` method on each event objects instead of doing `instance_eval` or `instance_variable_get` which is a bit cumbersome and also not clean.

Any opinion...?