### PR TITLE
Update rubocop 0.56.0 -> 1.12.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   TargetRubyVersion: 2.4
   Exclude:
     - 'examples/**/*'
+  NewCops: disable
 
 Gemspec/RequiredRubyVersion:
   Enabled: false
@@ -34,10 +35,14 @@ Style/EachWithObject:
   Enabled: false
 Style/FrozenStringLiteralComment:
   Enabled: false
+Style/StringConcatenation:
+  Enabled: false
+Style/RedundantAssignment:
+  Enabled: false
 
 Naming/HeredocDelimiterNaming:
   Enabled: false
-Naming/UncommunicativeMethodParamName:
+Naming/MethodParameterName:
   Enabled: false
 Naming/ConstantName:
   Enabled: false
@@ -45,9 +50,9 @@ Naming/AccessorMethodName:
   Enabled: false
 Naming/MethodName:
   Enabled: false
+Naming/FileName:
+  Enabled: false
 
-Metrics/LineLength:
-  Max: 200
 Metrics/BlockLength:
   Enabled: false
 Metrics/MethodLength:
@@ -55,11 +60,15 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Enabled: false
 
+Layout/LineLength:
+  Max: 200
 Layout/SpaceInsideBlockBraces:
+  Enabled: false
+Layout/HashAlignment:
   Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
   Enabled: false
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   Enabled: false
 Layout/ExtraSpacing:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,5 @@ gemspec
 group :development, :test do
   # ref: http://docs.rubocop.org/en/latest/installation/
   gem 'rubocop', '~> 1.12.1', require: false
-  gem 'rubocop-rake', '~> 0.3.1', require: false
-  gem 'rubocop-rspec', '~> 2.4.0', require: false
   gem 'yard', '~> 0.9.20'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ gemspec
 
 group :development, :test do
   # ref: http://docs.rubocop.org/en/latest/installation/
-  gem 'rubocop', '~> 0.56.0', require: false
+  gem 'rubocop', '~> 1.12.1', require: false
+  gem 'rubocop-rake', '~> 0.3.1', require: false
+  gem 'rubocop-rspec', '~> 2.4.0', require: false
   gem 'yard', '~> 0.9.20'
 end

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -954,7 +954,7 @@ module Line
       def validate_signature(content, channel_signature)
         return false if !channel_signature || !channel_secret
 
-        hash = OpenSSL::HMAC.digest(OpenSSL::Digest::SHA256.new, channel_secret, content)
+        hash = OpenSSL::HMAC.digest(OpenSSL::Digest.new('SHA256'), channel_secret, content)
         signature = Base64.strict_encode64(hash)
 
         variable_secure_compare(channel_signature, signature)
@@ -986,6 +986,7 @@ module Line
         if file.respond_to?(:content_type)
           content_type = file.content_type
           raise ArgumentError, "invalid content type: #{content_type}" unless ['image/jpeg', 'image/png'].include?(content_type)
+
           content_type
         else
           case file.path

--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version     = '>= 2.4.0'
 
   spec.add_development_dependency "addressable", "~> 2.3"
-  spec.add_development_dependency "bundler", "~> 1.11" if RUBY_VERSION < "2.3"
   spec.add_development_dependency 'rake', "~> 13.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "webmock", "~> 3.8"


### PR DESCRIPTION
- Disable NewCops by default
- Follow the rubycop's incompatible changes(e.g. rule name modification)
- Apply automatic correct for lib/line/bot/client.rb
- Do not use RUBY_VERSION in line-bot-api.gemspec
  https://sue445.hatenablog.com/entry/2016/09/02/121047
- Install rubycop-rake, rubycop-rspec
  (suggested by rubocop)