### PR TITLE
create set_rich_menu_alias and unset_rich_menu_alias method

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -492,6 +492,31 @@ module Line
         delete(endpoint, endpoint_path, credentials)
       end
 
+      # Set rich menu alias
+      #
+      # @param rich_menu_id [String] ID of an uploaded rich menu
+      # @param rich_menu_alias_id [String] string of alias words rich menu
+      #
+      # @return [Net::HTTPResponse]
+      def set_rich_menus_alias(rich_menu_id, rich_menu_alias_id)
+        channel_token_required
+
+        endpoint_path = '/bot/richmenu/alias'
+        post(endpoint, endpoint_path, { richMenuId: rich_menu_id, richMenuAliasId: rich_menu_alias_id }.to_json, credentials)
+      end
+
+      # Unset rich menu alias
+      #
+      # @param rich_menu_alias_id [String] string of alias words rich menu
+      #
+      # @return [Net::HTTPResponse]
+      def unset_rich_menus_alias(rich_menu_alias_id)
+        channel_token_required
+
+        endpoint_path = "/bot/richmenu/alias/#{rich_menu_alias_id}"
+        delete(endpoint, endpoint_path, credentials)
+      end
+
       # Link a rich menu to a user
       #
       # If you want to link a rich menu to multiple users,

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -120,6 +120,22 @@ describe Line::Bot::Client do
     expect(WebMock).to have_requested(:delete, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/all/richmenu')
   end
 
+  it 'creates a rich menu alias' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias'
+    stub_request(:post, uri_template).to_return(body: '{}', status: 200)
+
+    client.set_rich_menus_alias('1234567', 'alias-1234567')
+    expect(WebMock).to have_requested(:post, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias')
+  end
+
+  fit 'deletes a rich menu alias' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567'
+    stub_request(:delete, uri_template).to_return(body: '{}', status: 200)
+
+    client.unset_rich_menus_alias('alias-1234567')
+    expect(WebMock).to have_requested(:delete, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567')
+  end
+
   it 'links a rich menu to a user' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/user/1234567/richmenu/7654321'
     stub_request(:post, uri_template).to_return(body: '{}', status: 200)


### PR DESCRIPTION
thanks to support line bot api. I always use this gem :)

i'd like to write new rich menu api article on ruby.
- issue: https://github.com/line/line-bot-sdk-ruby/issues/232


i'd like to run this sample code. so, i add needed set_rich_menu_alias, unset_rich_menu_alias method.
https://developers.line.biz/ja/docs/messaging-api/using-rich-menus/