### PR TITLE
add update/get/get_list rich_menu_alias

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -578,6 +578,41 @@ module Line
         delete(endpoint, endpoint_path, credentials)
       end
 
+      # Update rich menu alias
+      #
+      # @param rich_menu_id [String] ID of an uploaded rich menu
+      # @param rich_menu_alias_id [String] string of alias words rich menu
+      #
+      # @return [Net::HTTPResponse]
+      def update_rich_menus_alias(rich_menu_id, rich_menu_alias_id)
+        channel_token_required
+
+        endpoint_path = "/bot/richmenu/alias/#{rich_menu_alias_id}"
+        post(endpoint, endpoint_path, { richMenuId: rich_menu_id }.to_json, credentials)
+      end
+
+      # Get a rich menu alias via a rich menu alias ID
+      #
+      # @param rich_menu_alias_id [String] string of alias words rich menu
+      #
+      # @return [Net::HTTPResponse]
+      def get_rich_menus_alias(rich_menu_alias_id)
+        channel_token_required
+
+        endpoint_path = "/bot/richmenu/alias/#{rich_menu_alias_id}"
+        get(endpoint, endpoint_path, credentials)
+      end
+
+      # Get a list of all uploaded rich menus alias
+      #
+      # @return [Net::HTTPResponse]
+      def get_rich_menus_alias_list
+        channel_token_required
+
+        endpoint_path = "/bot/richmenu/alias/list"
+        get(endpoint, endpoint_path, credentials)
+      end
+
       # Link a rich menu to a user
       #
       # If you want to link a rich menu to multiple users,

--- a/spec/line/bot/rich_menu_spec.rb
+++ b/spec/line/bot/rich_menu_spec.rb
@@ -38,6 +38,23 @@ RICH_MENU_LIST_CONTENT = <<"EOS"
 }
 EOS
 
+RICH_MENU_ALIAS_CONTENT = <<"EOS"
+{
+  {
+    "richMenuAliasId": "alias-1234567",
+    "richMenuId": "1234567"
+  }
+}
+EOS
+
+RICH_MENU_ALIAS_LIST_CONTENT = <<"EOS"
+{
+  "aliases": [
+    #{RICH_MENU_ALIAS_CONTENT}
+  ]
+}
+EOS
+
 RICH_MENU_IMAGE_FILE_PATH = 'spec/fixtures/line/bot/rich_menu_01.png'
 RICH_MENU_INVALID_FILE_EXTENSION_PATH = 'spec/fixtures/line/bot/rich_menu_01.txt'
 
@@ -128,12 +145,36 @@ describe Line::Bot::Client do
     expect(WebMock).to have_requested(:post, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias')
   end
 
-  fit 'deletes a rich menu alias' do
+  it 'deletes a rich menu alias' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567'
     stub_request(:delete, uri_template).to_return(body: '{}', status: 200)
 
     client.unset_rich_menus_alias('alias-1234567')
     expect(WebMock).to have_requested(:delete, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567')
+  end
+
+  it 'update a rich menu alias' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567'
+    stub_request(:post, uri_template).to_return(body: '{}', status: 200)
+
+    client.update_rich_menus_alias('1234567', 'alias-1234567')
+    expect(WebMock).to have_requested(:post, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567')
+  end
+
+  it 'get a rich menu alias' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567'
+    stub_request(:get, uri_template).to_return(body: RICH_MENU_ALIAS_CONTENT, status: 200)
+
+    client.get_rich_menus_alias('alias-1234567')
+    expect(WebMock).to have_requested(:get, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/alias-1234567')
+  end
+
+  it 'get a rich menu alias list' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/list'
+    stub_request(:get, uri_template).to_return(body: RICH_MENU_ALIAS_LIST_CONTENT, status: 200)
+
+    client.get_rich_menus_alias_list
+    expect(WebMock).to have_requested(:get, Line::Bot::API::DEFAULT_ENDPOINT + '/bot/richmenu/alias/list')
   end
 
   it 'links a rich menu to a user' do


### PR DESCRIPTION
add rich menu alias api :)
which is forget in https://github.com/line/line-bot-sdk-ruby/pull/233

so rich menu alias api is complete in this pr.

document from here: https://developers.line.biz/en/reference/messaging-api/#create-rich-menu-alias
already apply rich menu alias create/delete
apply rich menu alias update/get/get list