### PR TITLE
Don't require channel_id & channel_secret when call api related to JWT

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -116,9 +116,6 @@ module Line
       #
       # @return [Net::HTTPResponse]
       def issue_channel_access_token_jwt(jwt)
-        channel_id_required
-        channel_secret_required
-
         endpoint_path = '/oauth2/v2.1/token'
         payload = URI.encode_www_form(
           grant_type: 'client_credentials',
@@ -154,9 +151,6 @@ module Line
       #
       # @return [Net::HTTPResponse]
       def get_channel_access_token_key_ids_jwt(jwt)
-        channel_id_required
-        channel_secret_required
-
         payload = URI.encode_www_form(
           client_assertion_type: 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer',
           client_assertion: jwt


### PR DESCRIPTION
Thank you for the maintenance of this gem.
Since `channel_id` and `channel_secret` are not used in the following two APIs,  make both not required.

- [Issue channel access token v2.1](https://developers.line.biz/en/reference/messaging-api/#issue-channel-access-token-v2-1)
- [Get all valid channel access token key IDs v2.1](https://developers.line.biz/en/reference/messaging-api/#get-all-valid-channel-access-token-key-ids-v2-1)