### PR TITLE
add kitchensink README.md

### DIFF
--- a/examples/kitchensink/README.md
+++ b/examples/kitchensink/README.md
@@ -1,0 +1,16 @@
+# Kitchen Sink Bot
+
+A kitchen-sink LINE bot example
+
+## Getting started
+
+```ruby
+$ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
+$ export LINE_CHANNEL_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+$ bundle install
+$ bundle exec ruby app.rb
+```
+
+```
+https://your.base.url:4567/callback
+```


### PR DESCRIPTION
add README.md for kitchensink example.

I thought about whether to refer to the README for python or nodejs.
Referred to the README, which is as light as python.

[nodejs](https://github.com/line/line-bot-sdk-nodejs/blob/next/examples/kitchensink/README.md)
[python](https://github.com/line/line-bot-sdk-python/blob/master/examples/flask-kitchensink/README.md)