### PR TITLE
additional request body for push_message and multicast

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -166,14 +166,15 @@ module Line
       # @param user_id [String] User Id
       # @param messages [Hash or Array] Message Objects
       # @param headers [Hash] HTTP Headers
+      # @param payload [Hash] Additional request body
       # @return [Net::HTTPResponse]
-      def push_message(user_id, messages, headers: {})
+      def push_message(user_id, messages, headers: {}, payload: {})
         channel_token_required
 
         messages = [messages] if messages.is_a?(Hash)
 
         endpoint_path = '/bot/message/push'
-        payload = { to: user_id, messages: messages }.to_json
+        payload = payload.merge({ to: user_id, messages: messages }).to_json
         post(endpoint, endpoint_path, payload, credentials.merge(headers))
       end
 
@@ -212,15 +213,16 @@ module Line
       # @param to [Array or String] Array of userIds
       # @param messages [Hash or Array] Message Objects
       # @param headers [Hash] HTTP Headers
+      # @param payload [Hash] Additional request body
       # @return [Net::HTTPResponse]
-      def multicast(to, messages, headers: {})
+      def multicast(to, messages, headers: {}, payload: {})
         channel_token_required
 
         to = [to] if to.is_a?(String)
         messages = [messages] if messages.is_a?(Hash)
 
         endpoint_path = '/bot/message/multicast'
-        payload = { to: to, messages: messages }.to_json
+        payload = payload.merge({ to: to, messages: messages }).to_json
         post(endpoint, endpoint_path, payload, credentials.merge(headers))
       end
 

--- a/spec/line/bot/send_message_01_text_spec.rb
+++ b/spec/line/bot/send_message_01_text_spec.rb
@@ -37,19 +37,19 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'text',
-      'text' => 'Hello, world'
+      type: 'text',
+      text: 'Hello, world'
     }
     response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' =>  user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the text message' do
@@ -110,19 +110,19 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' =>  'text',
-      'text' => 'Hello, world'
+      type: 'text',
+      text: 'Hello, world'
     }
-    response = client.multicast(user_ids, message, payload: { customAggregationUnits: ['test']})
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
       ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'broadcasts the text message' do

--- a/spec/line/bot/send_message_01_text_spec.rb
+++ b/spec/line/bot/send_message_01_text_spec.rb
@@ -27,6 +27,31 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'push the text message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'text',
+      'text' => 'Hello, world'
+    }
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
+
+    expected = {
+      'to' =>  user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the text message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -73,6 +98,31 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the text message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' =>  'text',
+      'text' => 'Hello, world'
+    }
+    response = client.multicast(user_ids, message, payload: { customAggregationUnits: ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 
   it 'broadcasts the text message' do

--- a/spec/line/bot/send_message_02_image_spec.rb
+++ b/spec/line/bot/send_message_02_image_spec.rb
@@ -38,20 +38,20 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'image',
-      'originalContentUrl' => 'https://example.com/image.jpg',
-      'previewImageUrl' => 'https://example.com/image_preview.jpg',
+      type: 'image',
+      originalContentUrl: 'https://example.com/image.jpg',
+      previewImageUrl: 'https://example.com/image_preview.jpg',
     }
     response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the image message' do
@@ -114,19 +114,19 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'image',
-      'originalContentUrl' => 'https://example.com/image.jpg',
-      'previewImageUrl' => 'https://example.com/image_preview.jpg',
+      type: 'image',
+      originalContentUrl: 'https://example.com/image.jpg',
+      previewImageUrl: 'https://example.com/image_preview.jpg',
     }
     response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_02_image_spec.rb
+++ b/spec/line/bot/send_message_02_image_spec.rb
@@ -28,6 +28,32 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the image message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'image',
+      'originalContentUrl' => 'https://example.com/image.jpg',
+      'previewImageUrl' => 'https://example.com/image_preview.jpg',
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the image message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -76,5 +102,31 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the image message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'image',
+      'originalContentUrl' => 'https://example.com/image.jpg',
+      'previewImageUrl' => 'https://example.com/image_preview.jpg',
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_03_video_spec.rb
+++ b/spec/line/bot/send_message_03_video_spec.rb
@@ -28,6 +28,32 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the video message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'video',
+      'originalContentUrl' => 'https://example.com/video.mp4',
+      'previewImageUrl' => 'https://example.com/video_preview.jpg',
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the video message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -76,5 +102,31 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the video message' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'video',
+      'originalContentUrl' => 'https://example.com/video.mp4',
+      'previewImageUrl' => 'https://example.com/video_preview.jpg',
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_03_video_spec.rb
+++ b/spec/line/bot/send_message_03_video_spec.rb
@@ -38,20 +38,20 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'video',
-      'originalContentUrl' => 'https://example.com/video.mp4',
-      'previewImageUrl' => 'https://example.com/video_preview.jpg',
+      type: 'video',
+      originalContentUrl: 'https://example.com/video.mp4',
+      previewImageUrl: 'https://example.com/video_preview.jpg',
     }
     response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the video message' do
@@ -114,19 +114,19 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'video',
-      'originalContentUrl' => 'https://example.com/video.mp4',
-      'previewImageUrl' => 'https://example.com/video_preview.jpg',
+      type: 'video',
+      originalContentUrl: 'https://example.com/video.mp4',
+      previewImageUrl: 'https://example.com/video_preview.jpg',
     }
     response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_04_audio_spec.rb
+++ b/spec/line/bot/send_message_04_audio_spec.rb
@@ -28,6 +28,32 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the audio message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'audio',
+      'originalContentUrl' => 'https://example.com/audio.mp3',
+      'duration' => 120000
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the audio message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -76,5 +102,31 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the audio message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'audio',
+      'originalContentUrl' => 'https://example.com/audio.mp3',
+      'duration' => 120000
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_04_audio_spec.rb
+++ b/spec/line/bot/send_message_04_audio_spec.rb
@@ -38,20 +38,20 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'audio',
-      'originalContentUrl' => 'https://example.com/audio.mp3',
-      'duration' => 120000
+      type: 'audio',
+      originalContentUrl: 'https://example.com/audio.mp3',
+      duration: 120000
     }
     response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the audio message' do
@@ -114,19 +114,19 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'audio',
-      'originalContentUrl' => 'https://example.com/audio.mp3',
-      'duration' => 120000
+      type: 'audio',
+      originalContentUrl: 'https://example.com/audio.mp3',
+      duration: 120000
     }
     response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_05_location_spec.rb
+++ b/spec/line/bot/send_message_05_location_spec.rb
@@ -15,7 +15,7 @@ describe Line::Bot::Client do
     message = {
       type: 'location',
       title: 'National Diet Building',
-      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014',
       latitude: 35.675862,
       longitude: 139.744967,
     }
@@ -42,7 +42,7 @@ describe Line::Bot::Client do
     message = {
       type: 'location',
       title: 'National Diet Building',
-      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014',
       latitude: 35.675862,
       longitude: 139.744967,
     }
@@ -70,7 +70,7 @@ describe Line::Bot::Client do
     message = {
       type: 'location',
       title: 'National Diet Building',
-      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014',
       latitude: 35.675862,
       longitude: 139.744967,
     }
@@ -97,7 +97,7 @@ describe Line::Bot::Client do
     message = {
       type: 'location',
       title: 'National Diet Building',
-      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014',
       latitude: 35.675862,
       longitude: 139.744967,
     }
@@ -124,7 +124,7 @@ describe Line::Bot::Client do
     message = {
       type: 'location',
       title: 'National Diet Building',
-      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014',
       latitude: 35.675862,
       longitude: 139.744967,
     }

--- a/spec/line/bot/send_message_05_location_spec.rb
+++ b/spec/line/bot/send_message_05_location_spec.rb
@@ -14,10 +14,10 @@ describe Line::Bot::Client do
     user_id = 'user_id'
     message = {
       type: 'location',
-      title: 'LINE Corporation.',
-      address: 'Hikarie  Shibuya-ku Tokyo 151-0002',
-      latitude: 35.61823286112982,
-      longitude: 139.72824096679688,
+      title: 'National Diet Building',
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      latitude: 35.675862,
+      longitude: 139.744967,
     }
     response = client.push_message(user_id, message)
 
@@ -41,10 +41,10 @@ describe Line::Bot::Client do
     user_id = 'user_id'
     message = {
       type: 'location',
-      title: 'LINE Corporation.',
-      address: 'Hikarie  Shibuya-ku Tokyo 151-0002',
-      latitude: 35.61823286112982,
-      longitude: 139.72824096679688,
+      title: 'National Diet Building',
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      latitude: 35.675862,
+      longitude: 139.744967,
     }
     response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
@@ -69,10 +69,10 @@ describe Line::Bot::Client do
     reply_token = 'reply_token'
     message = {
       type: 'location',
-      title: 'LINE Corporation.',
-      address: 'Hikarie  Shibuya-ku Tokyo 151-0002',
-      latitude: 35.61823286112982,
-      longitude: 139.72824096679688,
+      title: 'National Diet Building',
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      latitude: 35.675862,
+      longitude: 139.744967,
     }
     response = client.reply_message(reply_token, message)
 
@@ -96,10 +96,10 @@ describe Line::Bot::Client do
     user_ids = ['user1', 'user2']
     message = {
       type: 'location',
-      title: 'LINE Corporation.',
-      address: 'Hikarie  Shibuya-ku Tokyo 151-0002',
-      latitude: 35.61823286112982,
-      longitude: 139.72824096679688,
+      title: 'National Diet Building',
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      latitude: 35.675862,
+      longitude: 139.744967,
     }
     response = client.multicast(user_ids, message)
 
@@ -123,10 +123,10 @@ describe Line::Bot::Client do
     user_ids = ['user1', 'user2']
     message = {
       type: 'location',
-      title: 'LINE Corporation.',
-      address: 'Hikarie  Shibuya-ku Tokyo 151-0002',
-      latitude: 35.61823286112982,
-      longitude: 139.72824096679688,
+      title: 'National Diet Building',
+      address: 'Nagatacho 1-7-1 Chiyoda-ku, Tokyo 100-0014'
+      latitude: 35.675862,
+      longitude: 139.744967,
     }
     response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 

--- a/spec/line/bot/send_message_05_location_spec.rb
+++ b/spec/line/bot/send_message_05_location_spec.rb
@@ -40,22 +40,22 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'location',
-      'title' => 'LINE Corporation.',
-      'address' => 'Hikarie  Shibuya-ku Tokyo 151-0002',
-      'latitude' => 35.61823286112982,
-      'longitude' => 139.72824096679688,
+      type: 'location',
+      title: 'LINE Corporation.',
+      address: 'Hikarie  Shibuya-ku Tokyo 151-0002',
+      latitude: 35.61823286112982,
+      longitude: 139.72824096679688,
     }
-    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the location message' do
@@ -122,21 +122,21 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'location',
-      'title' => 'LINE Corporation.',
-      'address' => 'Hikarie  Shibuya-ku Tokyo 151-0002',
-      'latitude' => 35.61823286112982,
-      'longitude' => 139.72824096679688,
+      type: 'location',
+      title: 'LINE Corporation.',
+      address: 'Hikarie  Shibuya-ku Tokyo 151-0002',
+      latitude: 35.61823286112982,
+      longitude: 139.72824096679688,
     }
-    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_05_location_spec.rb
+++ b/spec/line/bot/send_message_05_location_spec.rb
@@ -30,6 +30,34 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the location message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'location',
+      'title' => 'LINE Corporation.',
+      'address' => 'Hikarie  Shibuya-ku Tokyo 151-0002',
+      'latitude' => 35.61823286112982,
+      'longitude' => 139.72824096679688,
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the location message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -82,5 +110,33 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the location message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'location',
+      'title' => 'LINE Corporation.',
+      'address' => 'Hikarie  Shibuya-ku Tokyo 151-0002',
+      'latitude' => 35.61823286112982,
+      'longitude' => 139.72824096679688,
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_06_sticker_spec.rb
+++ b/spec/line/bot/send_message_06_sticker_spec.rb
@@ -28,6 +28,32 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the sticker message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'sticker',
+      'packageId' => '2',
+      'stickerId' => '144',
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the sticker message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -76,5 +102,31 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the sticker message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'sticker',
+      'packageId' => '2',
+      'stickerId' => '144',
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_06_sticker_spec.rb
+++ b/spec/line/bot/send_message_06_sticker_spec.rb
@@ -38,20 +38,20 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'sticker',
-      'packageId' => '2',
-      'stickerId' => '144',
+      type: 'sticker',
+      packageId: '2',
+      stickerId: '144',
     }
-    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the sticker message' do
@@ -114,19 +114,19 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'sticker',
-      'packageId' => '2',
-      'stickerId' => '144',
+      type: 'sticker',
+      packageId: '2',
+      stickerId: '144',
     }
-    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_07_imagemap_spec.rb
+++ b/spec/line/bot/send_message_07_imagemap_spec.rb
@@ -64,46 +64,46 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'imagemap',
-      'baseUrl' => 'https://example.com/image',
-      'altText' => 'this is an imagemap message',
-      'baseSize' => {
-        'width' => 1040,
-        'height' => 1040,
+      type: 'imagemap',
+      baseUrl: 'https://example.com/image',
+      altText: 'this is an imagemap message',
+      baseSize: {
+        width: 1040,
+        height: 1040,
       },
-      'actions' => [
+      actions: [
         {
-          'type' => 'uri',
-          'linkUri' => 'https://github.com/line/line-bot-sdk-ruby',
-          'area' => {
-            'x' => 0,
-            'y' => 0,
-            'width' => 520,
-            'height' => 1040,
+          type: 'uri',
+          linkUri: 'https://github.com/line/line-bot-sdk-ruby',
+          area: {
+            x: 0,
+            y: 0,
+            width: 520,
+            height: 1040,
           },
         },
         {
-          'type' => 'message',
-          'text' => 'Hello',
-          'area' => {
-            'x' => 520,
-            'y' => 0,
-            'width' => 520,
-            'height' => 1040,
+          type: 'message',
+          text: 'Hello',
+          area: {
+            x: 520,
+            y: 0,
+            width: 520,
+            height: 1040,
           },
         },
       ],
     }
-    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the imagemap message' do
@@ -218,45 +218,45 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'imagemap',
-      'baseUrl' => 'https://example.com/image',
-      'altText' => 'this is an imagemap message',
-      'baseSize' => {
-        'width' => 1040,
-        'height' => 1040,
+      type: 'imagemap',
+      baseUrl: 'https://example.com/image',
+      altText: 'this is an imagemap message',
+      baseSize: {
+        width: 1040,
+        height: 1040,
       },
-      'actions' => [
+      actions: [
         {
-          'type' => 'uri',
-          'linkUri' => 'https://github.com/line/line-bot-sdk-ruby',
-          'area' => {
-            'x' => 0,
-            'y' => 0,
-            'width' => 520,
-            'height' => 1040,
+          type: 'uri',
+          linkUri: 'https://github.com/line/line-bot-sdk-ruby',
+          area: {
+            x: 0,
+            y: 0,
+            width: 520,
+            height: 1040,
           },
         },
         {
-          'type' => 'message',
-          'text' => 'Hello',
-          'area' => {
-            'x' => 520,
-            'y' => 0,
-            'width' => 520,
-            'height' => 1040,
+          type: 'message',
+          text: 'Hello',
+          area: {
+            x: 520,
+            y: 0,
+            width: 520,
+            height: 1040,
           },
         },
       ],
     }
-    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_07_imagemap_spec.rb
+++ b/spec/line/bot/send_message_07_imagemap_spec.rb
@@ -54,6 +54,58 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the imagemap message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'imagemap',
+      'baseUrl' => 'https://example.com/image',
+      'altText' => 'this is an imagemap message',
+      'baseSize' => {
+        'width' => 1040,
+        'height' => 1040,
+      },
+      'actions' => [
+        {
+          'type' => 'uri',
+          'linkUri' => 'https://github.com/line/line-bot-sdk-ruby',
+          'area' => {
+            'x' => 0,
+            'y' => 0,
+            'width' => 520,
+            'height' => 1040,
+          },
+        },
+        {
+          'type' => 'message',
+          'text' => 'Hello',
+          'area' => {
+            'x' => 520,
+            'y' => 0,
+            'width' => 520,
+            'height' => 1040,
+          },
+        },
+      ],
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the imagemap message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -154,5 +206,57 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the imagemap message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'imagemap',
+      'baseUrl' => 'https://example.com/image',
+      'altText' => 'this is an imagemap message',
+      'baseSize' => {
+        'width' => 1040,
+        'height' => 1040,
+      },
+      'actions' => [
+        {
+          'type' => 'uri',
+          'linkUri' => 'https://github.com/line/line-bot-sdk-ruby',
+          'area' => {
+            'x' => 0,
+            'y' => 0,
+            'width' => 520,
+            'height' => 1040,
+          },
+        },
+        {
+          'type' => 'message',
+          'text' => 'Hello',
+          'area' => {
+            'x' => 520,
+            'y' => 0,
+            'width' => 520,
+            'height' => 1040,
+          },
+        },
+      ],
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_08_image_carousel_spec.rb
+++ b/spec/line/bot/send_message_08_image_carousel_spec.rb
@@ -56,6 +56,60 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the image carousel message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| { body: request.body, status: 200 } }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'template',
+      'altText' => 'this is a image carousel template',
+      'template' => {
+        'type' => 'image_carousel',
+        'columns' => [
+          {
+            'imageUrl' => 'https://example.com/bot/images/item1.jpg',
+            'action' => {
+              'type' => 'postback',
+              'label' => 'Buy',
+              'data' => 'action=buy&itemid=111'
+            }
+          },
+          {
+            'imageUrl' => 'https://example.com/bot/images/item2.jpg',
+            'action' => {
+              'type' => 'message',
+              'label' => 'Yes',
+              'text' => 'yes'
+            }
+          },
+          {
+            'imageUrl' => 'https://example.com/bot/images/item3.jpg',
+            'action' => {
+              'type' => 'uri',
+              'label' => 'View detail',
+              'uri' => 'http://example.com/page/222'
+            }
+          }
+        ]
+      }
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the image carousel message' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| { body: request.body, status: 200 } }
@@ -160,5 +214,59 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the image carousel message with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| { body: request.body, status: 200 } }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = %w[user1 user2]
+    message = {
+      'type' => 'template',
+      'altText' => 'this is a image carousel template',
+      'template' => {
+        'type' => 'image_carousel',
+        'columns' => [
+          {
+            'imageUrl' => 'https://example.com/bot/images/item1.jpg',
+            'action' => {
+              'type' => 'postback',
+              'label' => 'Buy',
+              'data' => 'action=buy&itemid=111'
+            }
+          },
+          {
+            'imageUrl' => 'https://example.com/bot/images/item2.jpg',
+            'action' => {
+              'type' => 'message',
+              'label' => 'Yes',
+              'text' => 'yes'
+            }
+          },
+          {
+            'imageUrl' => 'https://example.com/bot/images/item3.jpg',
+            'action' => {
+              'type' => 'uri',
+              'label' => 'View detail',
+              'uri' => 'http://example.com/page/222'
+            }
+          }
+        ]
+      }
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_08_image_carousel_spec.rb
+++ b/spec/line/bot/send_message_08_image_carousel_spec.rb
@@ -66,48 +66,48 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'template',
-      'altText' => 'this is a image carousel template',
-      'template' => {
-        'type' => 'image_carousel',
-        'columns' => [
+      type: 'template',
+      altText: 'this is a image carousel template',
+      template: {
+        type: 'image_carousel',
+        columns: [
           {
-            'imageUrl' => 'https://example.com/bot/images/item1.jpg',
-            'action' => {
-              'type' => 'postback',
-              'label' => 'Buy',
-              'data' => 'action=buy&itemid=111'
+            imageUrl: 'https://example.com/bot/images/item1.jpg',
+            action: {
+              type: 'postback',
+              label: 'Buy',
+              data: 'action=buy&itemid=111'
             }
           },
           {
-            'imageUrl' => 'https://example.com/bot/images/item2.jpg',
-            'action' => {
-              'type' => 'message',
-              'label' => 'Yes',
-              'text' => 'yes'
+            imageUrl: 'https://example.com/bot/images/item2.jpg',
+            action: {
+              type: 'message',
+              label: 'Yes',
+              text: 'yes'
             }
           },
           {
-            'imageUrl' => 'https://example.com/bot/images/item3.jpg',
-            'action' => {
-              'type' => 'uri',
-              'label' => 'View detail',
-              'uri' => 'http://example.com/page/222'
+            imageUrl: 'https://example.com/bot/images/item3.jpg',
+            action: {
+              type: 'uri',
+              label: 'View detail',
+              uri: 'http://example.com/page/222'
             }
           }
         ]
       }
     }
-    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the image carousel message' do
@@ -226,33 +226,33 @@ describe Line::Bot::Client do
 
     user_ids = %w[user1 user2]
     message = {
-      'type' => 'template',
-      'altText' => 'this is a image carousel template',
-      'template' => {
-        'type' => 'image_carousel',
-        'columns' => [
+      type: 'template',
+      altText: 'this is a image carousel template',
+      template: {
+        type: 'image_carousel',
+        columns: [
           {
-            'imageUrl' => 'https://example.com/bot/images/item1.jpg',
-            'action' => {
-              'type' => 'postback',
-              'label' => 'Buy',
-              'data' => 'action=buy&itemid=111'
+            imageUrl: 'https://example.com/bot/images/item1.jpg',
+            action: {
+              type: 'postback',
+              label: 'Buy',
+              data: 'action=buy&itemid=111'
             }
           },
           {
-            'imageUrl' => 'https://example.com/bot/images/item2.jpg',
-            'action' => {
-              'type' => 'message',
-              'label' => 'Yes',
-              'text' => 'yes'
+            imageUrl: 'https://example.com/bot/images/item2.jpg',
+            action: {
+              type: 'message',
+              label: 'Yes',
+              text: 'yes'
             }
           },
           {
-            'imageUrl' => 'https://example.com/bot/images/item3.jpg',
-            'action' => {
-              'type' => 'uri',
-              'label' => 'View detail',
-              'uri' => 'http://example.com/page/222'
+            imageUrl: 'https://example.com/bot/images/item3.jpg',
+            action: {
+              type: 'uri',
+              label: 'View detail',
+              uri: 'http://example.com/page/222'
             }
           }
         ]
@@ -261,12 +261,12 @@ describe Line::Bot::Client do
     response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_11_template_buttons_spec.rb
+++ b/spec/line/bot/send_message_11_template_buttons_spec.rb
@@ -50,6 +50,54 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the template message type buttons with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'buttons',
+        'thumbnailImageUrl' => 'https://example.com/image.jpg',
+        'title' => 'example',
+        'text' => 'test',
+        'actions' => [
+          {
+            'type' => 'message',
+            'label' => '1 label',
+            'text' => '1 text'
+          },
+          {
+            'type' => 'uri',
+            'label' => '2 label',
+            'uri' => 'tel:08041237177'
+          },
+          {
+            'type' => 'uri',
+            'label' => '3 label',
+            'uri' => 'http://google.com'
+          },
+        ]
+      }
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the template message type buttons' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -142,5 +190,53 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the template message type buttons with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'buttons',
+        'thumbnailImageUrl' => 'https://example.com/image.jpg',
+        'title' => 'example',
+        'text' => 'test',
+        'actions' => [
+          {
+            'type' => 'message',
+            'label' => '1 label',
+            'text' => '1 text'
+          },
+          {
+            'type' => 'uri',
+            'label' => '2 label',
+            'uri' => 'tel:08041237177'
+          },
+          {
+            'type' => 'uri',
+            'label' => '3 label',
+            'uri' => 'http://google.com'
+          },
+        ]
+      }
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_11_template_buttons_spec.rb
+++ b/spec/line/bot/send_message_11_template_buttons_spec.rb
@@ -60,42 +60,42 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'buttons',
-        'thumbnailImageUrl' => 'https://example.com/image.jpg',
-        'title' => 'example',
-        'text' => 'test',
-        'actions' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'buttons',
+        thumbnailImageUrl: 'https://example.com/image.jpg',
+        title: 'example',
+        text: 'test',
+        actions: [
           {
-            'type' => 'message',
-            'label' => '1 label',
-            'text' => '1 text'
+            type: 'message',
+            label: '1 label',
+            text: '1 text'
           },
           {
-            'type' => 'uri',
-            'label' => '2 label',
-            'uri' => 'tel:08041237177'
+            type: 'uri',
+            label: '2 label',
+            uri: 'tel:08041237177'
           },
           {
-            'type' => 'uri',
-            'label' => '3 label',
-            'uri' => 'http://google.com'
+            type: 'uri',
+            label: '3 label',
+            uri: 'http://google.com'
           },
         ]
       }
     }
-    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the template message type buttons' do
@@ -202,41 +202,41 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'buttons',
-        'thumbnailImageUrl' => 'https://example.com/image.jpg',
-        'title' => 'example',
-        'text' => 'test',
-        'actions' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'buttons',
+        thumbnailImageUrl: 'https://example.com/image.jpg',
+        title: 'example',
+        text: 'test',
+        actions: [
           {
-            'type' => 'message',
-            'label' => '1 label',
-            'text' => '1 text'
+            type: 'message',
+            label: '1 label',
+            text: '1 text'
           },
           {
-            'type' => 'uri',
-            'label' => '2 label',
-            'uri' => 'tel:08041237177'
+            type: 'uri',
+            label: '2 label',
+            uri: 'tel:08041237177'
           },
           {
-            'type' => 'uri',
-            'label' => '3 label',
-            'uri' => 'http://google.com'
+            type: 'uri',
+            label: '3 label',
+            text: 'http://google.com'
           },
         ]
       }
     }
-    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_12_template_confirm_spec.rb
+++ b/spec/line/bot/send_message_12_template_confirm_spec.rb
@@ -53,35 +53,35 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'confirm',
-        'text' => 'test',
-        'actions' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'confirm',
+        text: 'test',
+        actions: [
           {
-            'type' => 'message',
-            'label' => 'yes',
-            'text' => 'yes',
+            type: 'message',
+            label: 'yes',
+            text: 'yes',
           },
           {
-            'type' => 'message',
-            'label' => 'no',
-            'text' => 'no',
+            type: 'message',
+            label: 'no',
+            text: 'no',
           },
         ],
       }
     }
-    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the template message type confirm' do
@@ -174,34 +174,34 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'confirm',
-        'text' => 'test',
-        'actions' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'confirm',
+        text: 'test',
+        actions: [
           {
-            'type' => 'message',
-            'label' => 'yes',
-            'text' => 'yes',
+            type: 'message',
+            label: 'yes',
+            text: 'yes',
           },
           {
-            'type' => 'message',
-            'label' => 'no',
-            'text' => 'no',
+            type: 'message',
+            label: 'no',
+            text: 'no',
           },
         ],
       }
     }
-    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
       ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_12_template_confirm_spec.rb
+++ b/spec/line/bot/send_message_12_template_confirm_spec.rb
@@ -43,6 +43,47 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the template message type confirm' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'confirm',
+        'text' => 'test',
+        'actions' => [
+          {
+            'type' => 'message',
+            'label' => 'yes',
+            'text' => 'yes',
+          },
+          {
+            'type' => 'message',
+            'label' => 'no',
+            'text' => 'no',
+          },
+        ],
+      }
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the template message type confirm' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -121,5 +162,46 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the template message type confirm with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'confirm',
+        'text' => 'test',
+        'actions' => [
+          {
+            'type' => 'message',
+            'label' => 'yes',
+            'text' => 'yes',
+          },
+          {
+            'type' => 'message',
+            'label' => 'no',
+            'text' => 'no',
+          },
+        ],
+      }
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_13_template_carousel_spec.rb
+++ b/spec/line/bot/send_message_13_template_carousel_spec.rb
@@ -66,6 +66,70 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the template message type carousel with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'carousel',
+        'columns' => [
+          {
+            'thumbnailImageUrl' => 'https://example.com/image1.jpg',
+            'title' => 'example',
+            'text' => 'test',
+            'actions' => [
+              {
+                'type' => 'message',
+                'label' => 'keep',
+                'text' => 'keep'
+              },
+              {
+                'type' => 'uri',
+                'label' => 'site',
+                'uri' => 'https://example.com/page1'
+              },
+            ],
+          },
+          {
+            'thumbnailImageUrl' => 'https://example.com/image2.jpg',
+            'title' => 'example',
+            'text' => 'test',
+            'actions' => [
+              {
+                'type' => 'message',
+                'label' => 'keep',
+                'text' => 'keep'
+              },
+              {
+                'type' => 'uri',
+                'label' => 'site',
+                'uri' => 'https://example.com/page2'
+              },
+            ],
+          },
+        ],
+      }
+    }
+    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the template message type carousel' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -190,5 +254,69 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the template message type carousel with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'carousel',
+        'columns' => [
+          {
+            'thumbnailImageUrl' => 'https://example.com/image1.jpg',
+            'title' => 'example',
+            'text' => 'test',
+            'actions' => [
+              {
+                'type' => 'message',
+                'label' => 'keep',
+                'text' => 'keep'
+              },
+              {
+                'type' => 'uri',
+                'label' => 'site',
+                'uri' => 'https://example.com/page1'
+              },
+            ],
+          },
+          {
+            'thumbnailImageUrl' => 'https://example.com/image2.jpg',
+            'title' => 'example',
+            'text' => 'test',
+            'actions' => [
+              {
+                'type' => 'message',
+                'label' => 'keep',
+                'text' => 'keep'
+              },
+              {
+                'type' => 'uri',
+                'label' => 'site',
+                'uri' => 'https://example.com/page2'
+              },
+            ],
+          },
+        ],
+      }
+    }
+    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_13_template_carousel_spec.rb
+++ b/spec/line/bot/send_message_13_template_carousel_spec.rb
@@ -76,58 +76,58 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'carousel',
-        'columns' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'carousel',
+        columns: [
           {
-            'thumbnailImageUrl' => 'https://example.com/image1.jpg',
-            'title' => 'example',
-            'text' => 'test',
-            'actions' => [
+            thumbnailImageUrl: 'https://example.com/image1.jpg',
+            title: 'example',
+            text: 'test',
+            actions: [
               {
-                'type' => 'message',
-                'label' => 'keep',
-                'text' => 'keep'
+                type: 'message',
+                label: 'keep',
+                text: 'keep'
               },
               {
-                'type' => 'uri',
-                'label' => 'site',
-                'uri' => 'https://example.com/page1'
+                type: 'uri',
+                label: 'site',
+                uri: 'https://example.com/page1'
               },
             ],
           },
           {
-            'thumbnailImageUrl' => 'https://example.com/image2.jpg',
-            'title' => 'example',
-            'text' => 'test',
-            'actions' => [
+            thumbnailImageUrl: 'https://example.com/image2.jpg',
+            title: 'example',
+            text: 'test',
+            actions: [
               {
-                'type' => 'message',
-                'label' => 'keep',
-                'text' => 'keep'
+                type: 'message',
+                label: 'keep',
+                text: 'keep'
               },
               {
-                'type' => 'uri',
-                'label' => 'site',
-                'uri' => 'https://example.com/page2'
+                type: 'uri',
+                label: 'site',
+                uri: 'https://example.com/page2'
               },
             ],
           },
         ],
       }
     }
-    response = client.push_message(user_id, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the template message type carousel' do
@@ -266,57 +266,57 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'carousel',
-        'columns' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'carousel',
+        columns: [
           {
-            'thumbnailImageUrl' => 'https://example.com/image1.jpg',
-            'title' => 'example',
-            'text' => 'test',
-            'actions' => [
+            thumbnailImageUrl: 'https://example.com/image1.jpg',
+            title: 'example',
+            text: 'test',
+            actions: [
               {
-                'type' => 'message',
-                'label' => 'keep',
-                'text' => 'keep'
+                type: 'message',
+                label: 'keep',
+                text: 'keep'
               },
               {
-                'type' => 'uri',
-                'label' => 'site',
-                'uri' => 'https://example.com/page1'
+                type: 'uri',
+                label: 'site',
+                uri: 'https://example.com/page1'
               },
             ],
           },
           {
-            'thumbnailImageUrl' => 'https://example.com/image2.jpg',
-            'title' => 'example',
-            'text' => 'test',
-            'actions' => [
+            thumbnailImageUrl: 'https://example.com/image2.jpg',
+            title: 'example',
+            text: 'test',
+            actions: [
               {
-                'type' => 'message',
-                'label' => 'keep',
-                'text' => 'keep'
+                type: 'message',
+                label: 'keep',
+                text: 'keep'
               },
               {
-                'type' => 'uri',
-                'label' => 'site',
-                'uri' => 'https://example.com/page2'
+                type: 'uri',
+                label: 'site',
+                uri: 'https://example.com/page2'
               },
             ],
           },
         ],
       }
     }
-    response = client.multicast(user_ids, message, payload: {'customAggregationUnits' => ['test']})
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_14_template_datepicker_spec.rb
+++ b/spec/line/bot/send_message_14_template_datepicker_spec.rb
@@ -45,6 +45,49 @@ describe Line::Bot::Client do
     expect(response.body).to eq(expected)
   end
 
+  it 'pushes the template message type datepicker with additional payload' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/push'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_id = 'user_id'
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'buttons',
+        'title' => 'event schedule',
+        'text' => 'select date',
+        'actions' => [
+          {
+            'type' => 'datetimepicker',
+            'label' => 'ok',
+            'data' => 'datetimepicker=ok',
+            'mode' => 'date'
+          },
+          {
+            'type' => 'postback',
+            'label' => 'no',
+            'data' => 'datetimepicker=no',
+          },
+        ]
+      }
+    }
+    response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
+
+    expected = {
+      'to' => user_id,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
+  end
+
   it 'replies the template message type carousel' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/reply'
     stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
@@ -127,5 +170,48 @@ describe Line::Bot::Client do
       ]
     }.to_json
     expect(response.body).to eq(expected)
+  end
+
+  it 'multicasts the template message type carousel' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/multicast'
+    stub_request(:post, uri_template).to_return { |request| {body: request.body, status: 200} }
+
+    client = Line::Bot::Client.new do |config|
+      config.channel_token = 'channel_token'
+    end
+
+    user_ids = ['user1', 'user2']
+    message = {
+      'type' => 'template',
+      'altText' => 'this is an template message',
+      'template' => {
+        'type' => 'buttons',
+        'title' => 'event schedule',
+        'text' => 'select date',
+        'actions' => [
+          {
+            'type' => 'datetimepicker',
+            'label' => 'ok',
+            'data' => 'datetimepicker=ok',
+            'mode' => 'date'
+          },
+          {
+            'type' => 'postback',
+            'label' => 'no',
+            'data' => 'datetimepicker=no',
+          },
+        ]
+      }
+    }
+    response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
+
+    expected = {
+      'to' => user_ids,
+      'messages' => [
+        message
+      ],
+      'customAggregationUnits' => ['test']
+    }
+    expect(JSON.parse(response.body)).to eq(expected)
   end
 end

--- a/spec/line/bot/send_message_14_template_datepicker_spec.rb
+++ b/spec/line/bot/send_message_14_template_datepicker_spec.rb
@@ -55,23 +55,23 @@ describe Line::Bot::Client do
 
     user_id = 'user_id'
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'buttons',
-        'title' => 'event schedule',
-        'text' => 'select date',
-        'actions' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'buttons',
+        title: 'event schedule',
+        text: 'select date',
+        actions: [
           {
-            'type' => 'datetimepicker',
-            'label' => 'ok',
-            'data' => 'datetimepicker=ok',
-            'mode' => 'date'
+            type: 'datetimepicker',
+            label: 'ok',
+            data: 'datetimepicker=ok',
+            mode: 'date'
           },
           {
-            'type' => 'postback',
-            'label' => 'no',
-            'data' => 'datetimepicker=no',
+            type: 'postback',
+            label: 'no',
+            data: 'datetimepicker=no',
           },
         ]
       }
@@ -79,13 +79,13 @@ describe Line::Bot::Client do
     response = client.push_message(user_id, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_id,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_id,
+      messages: [
         message
       ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 
   it 'replies the template message type carousel' do
@@ -182,23 +182,23 @@ describe Line::Bot::Client do
 
     user_ids = ['user1', 'user2']
     message = {
-      'type' => 'template',
-      'altText' => 'this is an template message',
-      'template' => {
-        'type' => 'buttons',
-        'title' => 'event schedule',
-        'text' => 'select date',
-        'actions' => [
+      type: 'template',
+      altText: 'this is an template message',
+      template: {
+        type: 'buttons',
+        title: 'event schedule',
+        text: 'select date',
+        actions: [
           {
-            'type' => 'datetimepicker',
-            'label' => 'ok',
-            'data' => 'datetimepicker=ok',
-            'mode' => 'date'
+            type: 'datetimepicker',
+            label: 'ok',
+            data: 'datetimepicker=ok',
+            mode: 'date'
           },
           {
-            'type' => 'postback',
-            'label' => 'no',
-            'data' => 'datetimepicker=no',
+            type: 'postback',
+            label: 'no',
+            data: 'datetimepicker=no',
           },
         ]
       }
@@ -206,12 +206,12 @@ describe Line::Bot::Client do
     response = client.multicast(user_ids, message, payload: {customAggregationUnits: ['test']})
 
     expected = {
-      'to' => user_ids,
-      'messages' => [
+      customAggregationUnits: ['test'],
+      to: user_ids,
+      messages: [
         message
-      ],
-      'customAggregationUnits' => ['test']
-    }
-    expect(JSON.parse(response.body)).to eq(expected)
+      ]
+    }.to_json
+    expect(response.body).to eq(expected)
   end
 end


### PR DESCRIPTION
There is usecase for setting additional request body for `push_message` or `multicast` in messaging API's option for corporate customers:
https://developers.line.biz/en/reference/partner-docs/#assign-names-to-units-when-sending-messages

I'm not sure whether option for corporate customers should be supported by this gem, but submit this anyway.
If it is, I'm willing to work on more customAggregationUnits related issues in coming PR.

This is also useful for setting `notificationDisabled`.