### PR TITLE
Get the follower ids with a limit

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -333,15 +333,18 @@ module Line
 
       # Get user IDs of who added your LINE Official Account as a friend
       #
-      # @param continuation_token [String] Identifier to return next page
-      #                                   (next property to be included in the response)
+      # @param start [String] Identifier to return next page (next property to be included in the response)
+      # @param limit [Integer] The maximum number of user IDs to retrieve in a single request
       #
       # @return [Net::HTTPResponse]
-      def get_follower_ids(continuation_token = nil)
+      def get_follower_ids(start: nil, limit: nil)
         channel_token_required
 
+        params = { start: start, limit: limit }.compact
+
         endpoint_path = "/bot/followers/ids"
-        endpoint_path += "?start=#{continuation_token}" if continuation_token
+        endpoint_path += "?" unless params.empty?
+        endpoint_path += params.map { |key, value| "#{key}=#{value}" }.join("&")
         get(endpoint, endpoint_path, credentials)
       end
 

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -343,8 +343,7 @@ module Line
         params = { start: start, limit: limit }.compact
 
         endpoint_path = "/bot/followers/ids"
-        endpoint_path += "?" unless params.empty?
-        endpoint_path += params.map { |key, value| "#{key}=#{value}" }.join("&")
+        endpoint_path += "?" + URI.encode_www_form(params) unless params.empty?
         get(endpoint, endpoint_path, credentials)
       end
 

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -337,8 +337,13 @@ module Line
       # @param limit [Integer] The maximum number of user IDs to retrieve in a single request
       #
       # @return [Net::HTTPResponse]
-      def get_follower_ids(start: nil, limit: nil)
+      def get_follower_ids(deprecated_continuation_token = nil, start: nil, limit: nil)
         channel_token_required
+
+        if deprecated_continuation_token
+          warn "continuation_token as the first argument is deprecated. Please use :start instead."
+          start = deprecated_continuation_token
+        end
 
         params = { start: start, limit: limit }.compact
 


### PR DESCRIPTION
As per the following release, it is now possible to specify the number of friends' user IDs when retrieving them using `limit` parameter. See also: #244
https://developers.line.biz/en/news/2021/11/09/messaging-api-update/#messaging-api-202111-02

Here is one thing I would like to discuss. Right now we are passing the `continuation_token` parameter as an argument, but this is optional, not required. Ideally, we would like to pass this as a hash [like #narrowcast](https://github.com/line/line-bot-sdk-ruby/blob/d53025428765b069770e6d12ca3ba448f59b511f/lib/line/bot/client.rb#L257). Therefore, in this pull request, it is passed as a hash.

However, this would be a disruptive change to the existing interface. Therefore, one idea is to accept a value such as `deprecated_continuation_token` as the first argument, and print a warning that the value will be changed in the future.

```ruby
def get_follower_ids(deprecated_continuation_token = nil, start: nil, limit: nil)
  channel_token_required

  # Print a warning when there is a deprecated_continuation_token
  # ...

  params = { start: start, limit: limit }.compact

  endpoint_path = "/bot/followers/ids"
  endpoint_path += "?" unless params.empty?
  endpoint_path += params.map { |key, value| "#{key}=#{value}" }.join("&")
  get(endpoint, endpoint_path, credentials)
end
```

This pull request is still in draft status. Please let me know what you think. Thank you.