### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,14 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0', '3.1' ]
     name: Ruby v${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - run: gem install bundler
-    - run: bundle install
+        bundler-cache: true
     - run: bundle exec rubocop
     - run: bundle exec rspec


### PR DESCRIPTION
- Add Ruby 3.1 to CI
- Optimize Github Action

https://github.com/ruby/setup-ruby
> Note that any step doing bundle install (for the root Gemfile) or gem install bundler can be removed with bundler-cache: true.