### PR TITLE
Add ID token verification endpoint

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -166,6 +166,19 @@ module Line
         post(oauth_endpoint, endpoint_path, payload, headers)
       end
 
+      # Verify access token v2.1
+      #
+      # @param access_token [String] access token
+      #
+      # @return [Net::HTTPResponse]
+      def verify_access_token(access_token)
+        payload = URI.encode_www_form(
+          access_token: access_token
+        )
+        endpoint_path = "/oauth2/v2.1/verify?#{payload}"
+        get(oauth_endpoint, endpoint_path)
+      end
+
       # Get all valid channel access token key IDs v2.1
       #
       # @param jwt [String]

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -145,6 +145,25 @@ module Line
         post(oauth_endpoint, endpoint_path, payload, headers)
       end
 
+      # Verify ID token
+      #
+      # @param id_token [String] ID token
+      # @param options [Hash] Optional request body
+      #
+      # @return [Net::HTTPResponse]
+      def verify_id_token(id_token, options = {})
+        channel_id_required
+
+        endpoint_path = '/oauth2/v2.1/verify'
+        payload = URI.encode_www_form(
+          client_id: channel_id,
+          id_token: id_token,
+          **options
+        )
+        headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
+        post(oauth_endpoint, endpoint_path, payload, headers)
+      end
+
       # Get all valid channel access token key IDs v2.1
       #
       # @param jwt [String]

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -148,18 +148,20 @@ module Line
       # Verify ID token
       #
       # @param id_token [String] ID token
-      # @param options [Hash] Optional request body
+      # @param nonce [String] Expected nonce value. Use the nonce value provided in the authorization request. Omit if the nonce value was not specified in the authorization request.
+      # @param user_id [String] Expected user ID.
       #
       # @return [Net::HTTPResponse]
-      def verify_id_token(id_token, options = {})
+      def verify_id_token(id_token, nonce: nil, user_id: nil)
         channel_id_required
 
         endpoint_path = '/oauth2/v2.1/verify'
-        payload = URI.encode_www_form(
+        payload = URI.encode_www_form({
           client_id: channel_id,
           id_token: id_token,
-          **options
-        )
+          nonce: nonce,
+          user_id: user_id
+        }.compact)
         headers = { 'Content-Type' => 'application/x-www-form-urlencoded' }
         post(oauth_endpoint, endpoint_path, payload, headers)
       end

--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -195,6 +195,19 @@ module Line
         get(oauth_endpoint, endpoint_path, headers)
       end
 
+      # Get user profile by access token
+      #
+      # @param access_token [String] access token
+      #
+      # @return [Net::HTTPResponse]
+      def get_profile_by_access_token(access_token)
+        headers = {
+          "Authorization" => "Bearer #{access_token}",
+        }
+        endpoint_path = "/v2/profile"
+        get(oauth_endpoint, endpoint_path, headers)
+      end
+
       # Push messages to a user using user_id.
       #
       # @param user_id [String] User Id

--- a/spec/line/bot/client_channel_token_spec.rb
+++ b/spec/line/bot/client_channel_token_spec.rb
@@ -112,4 +112,15 @@ describe Line::Bot::Client do
 
     expect(response).to be_a(Net::HTTPOK)
   end
+
+  it 'verifies ID token' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_OAUTH_ENDPOINT + '/oauth2/v2.1/verify'
+    stub_request(:post, uri_template).to_return { |request| {body: '', status: 200} }
+
+    client = generate_client
+
+    response = client.verify_id_token('dummy_id_token', nonce: 'dummy_nonce')
+
+    expect(response).to be_a(Net::HTTPOK)
+  end
 end

--- a/spec/line/bot/client_channel_token_spec.rb
+++ b/spec/line/bot/client_channel_token_spec.rb
@@ -55,6 +55,15 @@ VERIFY_ACCESS_TOKEN_CONTENT = <<"EOS"
 }
 EOS
 
+PROFILE_BY_ACCESS_TOKEN_CONTENT = <<"EOS"
+{
+    "userId": "U4af4980629...",
+    "displayName": "Brown",
+    "pictureUrl": "https://profile.line-scdn.net/abcdefghijklmn",
+    "statusMessage": "Hello, LINE!"
+}
+EOS
+
 describe Line::Bot::Client do
   def dummy_config
     {
@@ -158,5 +167,18 @@ describe Line::Bot::Client do
     response = client.verify_access_token('dummy_access_token')
 
     expect(response).to be_a(Net::HTTPOK).and(have_attributes(body: VERIFY_ACCESS_TOKEN_CONTENT))
+  end
+
+  it 'gets profile by access token' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_OAUTH_ENDPOINT + '/v2/profile'
+    stub_request(:get, uri_template)
+      .with(headers: { 'Authorization' =>  'Bearer dummy_access_token'})
+      .to_return { |request| {body: PROFILE_BY_ACCESS_TOKEN_CONTENT, status: 200} }
+
+    client = generate_client
+
+    response = client.get_profile_by_access_token('dummy_access_token')
+
+    expect(response).to be_a(Net::HTTPOK).and(have_attributes(body: PROFILE_BY_ACCESS_TOKEN_CONTENT))
   end
 end

--- a/spec/line/bot/client_channel_token_spec.rb
+++ b/spec/line/bot/client_channel_token_spec.rb
@@ -47,6 +47,14 @@ VERIFY_ID_TOKEN_CONTENT = <<"EOS"
 }
 EOS
 
+VERIFY_ACCESS_TOKEN_CONTENT = <<"EOS"
+{
+    "scope": "profile",
+    "client_id": "1440057261",
+    "expires_in": 2591659
+}
+EOS
+
 describe Line::Bot::Client do
   def dummy_config
     {
@@ -139,5 +147,16 @@ describe Line::Bot::Client do
     response = client.verify_id_token('dummy_id_token', nonce: 'dummy_nonce')
 
     expect(response).to be_a(Net::HTTPOK).and(have_attributes(body: VERIFY_ID_TOKEN_CONTENT))
+  end
+
+  it 'verifies access token' do
+    uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_OAUTH_ENDPOINT + '/oauth2/v2.1/verify?access_token=dummy_access_token'
+    stub_request(:get, uri_template).to_return { |request| {body: VERIFY_ACCESS_TOKEN_CONTENT, status: 200} }
+
+    client = generate_client
+
+    response = client.verify_access_token('dummy_access_token')
+
+    expect(response).to be_a(Net::HTTPOK).and(have_attributes(body: VERIFY_ACCESS_TOKEN_CONTENT))
   end
 end

--- a/spec/line/bot/client_channel_token_spec.rb
+++ b/spec/line/bot/client_channel_token_spec.rb
@@ -32,6 +32,21 @@ GET_CHANNEL_ACCESS_TOKEN_KEY_IDS_JWT_CONTENT = <<"EOS"
 }
 EOS
 
+VERIFY_ID_TOKEN_CONTENT = <<"EOS"
+{
+    "iss": "https://access.line.me",
+    "sub": "U1234567890abcdef1234567890abcdef",
+    "aud": "1234567890",
+    "exp": 1504169092,
+    "iat": 1504263657,
+    "nonce": "0987654asdf",
+    "amr": ["pwd"],
+    "name": "Taro Line",
+    "picture": "https://sample_line.me/aBcdefg123456",
+    "email": "taro.line@example.com"
+}
+EOS
+
 describe Line::Bot::Client do
   def dummy_config
     {
@@ -115,12 +130,14 @@ describe Line::Bot::Client do
 
   it 'verifies ID token' do
     uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_OAUTH_ENDPOINT + '/oauth2/v2.1/verify'
-    stub_request(:post, uri_template).to_return { |request| {body: '', status: 200} }
+    stub_request(:post, uri_template)
+      .with(body: { client_id: 'channel id', id_token: 'dummy_id_token', nonce: 'dummy_nonce'})
+      .to_return { |request| {body: VERIFY_ID_TOKEN_CONTENT, status: 200} }
 
     client = generate_client
 
     response = client.verify_id_token('dummy_id_token', nonce: 'dummy_nonce')
 
-    expect(response).to be_a(Net::HTTPOK)
+    expect(response).to be_a(Net::HTTPOK).and(have_attributes(body: VERIFY_ID_TOKEN_CONTENT))
   end
 end


### PR DESCRIPTION
This is implementation for https://developers.line.biz/en/reference/line-login/#verify-id-token.

We need this for `liff.getIDToken()`.