### PR TITLE
Update CI target version of the ruby

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [ '2.4', '2.5', '2.6', '2.7', '3.0' ]
+        # https://www.ruby-lang.org/en/downloads/branches/
+        ruby: [ '2.7', '3.0', '3.1' ]
     name: Ruby v${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
2.4, 2.5, 2.6 was EOL.
3.1 was newly released.