### PR TITLE
Add APIs to validate message objects

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -535,6 +535,71 @@ module Line
         get(endpoint, endpoint_path, credentials)
       end
 
+      # Validate message objects of a reply message
+      #
+      # @param messages [Array] Array of message objects to validate
+      #
+      # @return [Net::HTTPResponse]
+      def validate_reply_message_objects(messages)
+        channel_token_required
+
+        endpoint_path = '/bot/message/validate/reply'
+        payload = { messages: messages }.to_json
+        post(endpoint, endpoint_path, payload, credentials)
+      end
+
+      # Validate message objects of a push message
+      #
+      # @param messages [Array] Array of message objects to validate
+      #
+      # @return [Net::HTTPResponse]
+      def validate_push_message_objects(messages)
+        channel_token_required
+
+        endpoint_path = '/bot/message/validate/push'
+        payload = { messages: messages }.to_json
+        post(endpoint, endpoint_path, payload, credentials)
+      end
+
+      # Validate message objects of a multicast message
+      #
+      # @param messages [Array] Array of message objects to validate
+      #
+      # @return [Net::HTTPResponse]
+      def validate_multicast_message_objects(messages)
+        channel_token_required
+
+        endpoint_path = '/bot/message/validate/multicast'
+        payload = { messages: messages }.to_json
+        post(endpoint, endpoint_path, payload, credentials)
+      end
+
+      # Validate message objects of a narrowcast message
+      #
+      # @param messages [Array] Array of message objects to validate
+      #
+      # @return [Net::HTTPResponse]
+      def validate_narrowcast_message_objects(messages)
+        channel_token_required
+
+        endpoint_path = '/bot/message/validate/narrowcast'
+        payload = { messages: messages }.to_json
+        post(endpoint, endpoint_path, payload, credentials)
+      end
+
+      # Validate message objects of a broadcast message
+      #
+      # @param messages [Array] Array of message objects to validate
+      #
+      # @return [Net::HTTPResponse]
+      def validate_broadcast_message_objects(messages)
+        channel_token_required
+
+        endpoint_path = '/bot/message/validate/broadcast'
+        payload = { messages: messages }.to_json
+        post(endpoint, endpoint_path, payload, credentials)
+      end
+
       # Create a rich menu
       #
       # @param rich_menu [Hash] The rich menu represented as a rich menu object

--- a/spec/line/bot/client_validate_message_objects_spec.rb
+++ b/spec/line/bot/client_validate_message_objects_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+require 'webmock/rspec'
+require 'json'
+
+MESSAGE_OBJECTS = {
+  messages: [
+    {
+      type: 'text',
+      text: 'Hello, world'
+    }
+  ]
+}
+
+RESPONSE_BODY = <<"EOS"
+{}
+EOS
+
+describe Line::Bot::Client do
+  def dummy_config
+    {
+      channel_token: 'access token',
+    }
+  end
+
+  def client
+    Line::Bot::Client.new do |config|
+      config.channel_token = dummy_config[:channel_token]
+    end
+  end
+
+  it 'validates message objects of a reply message' do
+    uri_template = Addressable::Template.new(Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/validate/reply')
+    stub_request(:post, uri_template).with(body: MESSAGE_OBJECTS).to_return { |request| { body: RESPONSE_BODY, status: 200 } }
+
+    messages = [
+      {
+        type: 'text',
+        text: 'Hello, world'
+      }
+    ]
+
+    response = client.validate_reply_message_objects(messages)
+    expect(response).to be_a(Net::HTTPOK)
+    expect(JSON.parse(response.body)).to eq({})
+  end
+
+  it 'validates message objects of a push message' do
+    uri_template = Addressable::Template.new(Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/validate/push')
+    stub_request(:post, uri_template).with(body: MESSAGE_OBJECTS).to_return { |request| { body: RESPONSE_BODY, status: 200 } }
+
+    messages = [
+      {
+        type: 'text',
+        text: 'Hello, world'
+      }
+    ]
+
+    response = client.validate_push_message_objects(messages)
+    expect(response).to be_a(Net::HTTPOK)
+    expect(JSON.parse(response.body)).to eq({})
+  end
+
+  it 'validates message objects of a multicast message' do
+    uri_template = Addressable::Template.new(Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/validate/multicast')
+    stub_request(:post, uri_template).with(body: MESSAGE_OBJECTS).to_return { |request| { body: RESPONSE_BODY, status: 200 } }
+
+    messages = [
+      {
+        type: 'text',
+        text: 'Hello, world'
+      }
+    ]
+
+    response = client.validate_multicast_message_objects(messages)
+    expect(response).to be_a(Net::HTTPOK)
+    expect(JSON.parse(response.body)).to eq({})
+  end
+
+  it 'validates message objects of a narrowcast message' do
+    uri_template = Addressable::Template.new(Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/validate/narrowcast')
+    stub_request(:post, uri_template).with(body: MESSAGE_OBJECTS).to_return { |request| { body: RESPONSE_BODY, status: 200 } }
+
+    messages = [
+      {
+        type: 'text',
+        text: 'Hello, world'
+      }
+    ]
+
+    response = client.validate_narrowcast_message_objects(messages)
+    expect(response).to be_a(Net::HTTPOK)
+    expect(JSON.parse(response.body)).to eq({})
+  end
+
+  it 'validates message objects of a broadcast message' do
+    uri_template = Addressable::Template.new(Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/validate/broadcast')
+    stub_request(:post, uri_template).with(body: MESSAGE_OBJECTS).to_return { |request| { body: RESPONSE_BODY, status: 200 } }
+
+    messages = [
+      {
+        type: 'text',
+        text: 'Hello, world'
+      }
+    ]
+
+    response = client.validate_broadcast_message_objects(messages)
+    expect(response).to be_a(Net::HTTPOK)
+    expect(JSON.parse(response.body)).to eq({})
+  end
+end


### PR DESCRIPTION
This PR resolves #267.

APIs to validate message objects have been added, and we would like to add the features to the SDK. 5 APIs have been added, but the request body, response, etc. are the same.

For reference, I tested the following code in a local environment.

```ruby
require 'line/bot'

def client
  @client ||= Line::Bot::Client.new { |config|
    config.channel_id = 'xxx'
    config.channel_secret = 'xxx'
    config.channel_token = 'xxx'
  }
end

messages = [
  {
    type: 'text',
    text: 'Hello, world'
  }
]

client.validate_reply_message_objects(messages)      #=> #<Net::HTTPOK 200 OK readbody=true>
client.validate_push_message_objects(messages)       #=> #<Net::HTTPOK 200 OK readbody=true>
client.validate_multicast_message_objects(messages)  #=> #<Net::HTTPOK 200 OK readbody=true>
client.validate_narrowcast_message_objects(messages) #=> #<Net::HTTPOK 200 OK readbody=true>
client.validate_broadcast_message_objects(messages)  #=> #<Net::HTTPOK 200 OK readbody=true>
```