### PR TITLE
Import release.yml to generate release note automatically based on label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  categories:
+    - title: Breaking Changes
+      labels:
+        - breaking-change
+    - title: line-openapi updates
+      labels:
+        - line-openapi-update
+    - title: New Features
+      labels:
+        - new-features
+    - title: Bug fix
+      labels:
+        - bug-fix
+    - title: Dependency updates
+      labels:
+        - dependency upgrade
+      exclude:
+        labels:
+          - line-openapi-update
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
same as https://github.com/line/line-bot-sdk-java/blob/master/.github/release.yml.

It will help us to create release note after https://github.com/line/line-bot-sdk-ruby/pull/296 completes.