### PR TITLE
Drop Ruby 2.7 and support Ruby 3.2 & 3.3

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # https://www.ruby-lang.org/en/downloads/branches/
-        ruby: [ '2.7', '3.0', '3.1' ]
+        ruby: [ '3.0', '3.1', '3.2', '3.3' ]
     name: Ruby v${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Also, generated documentation by YARD is available.
 
 - https://rubydoc.info/gems/line-bot-api
 
+## Requirements
+This library requires Ruby 3.0 or later.
+
 ## Installation
 
 Add this line to your application's Gemfile:


### PR DESCRIPTION
Resolve https://github.com/line/line-bot-sdk-ruby/issues/311

Note Ruby 3.0 will be EOL within 2 month.