### PR TITLE
Drop Ruby 3.0 support

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # https://www.ruby-lang.org/en/downloads/branches/
-        ruby: [ '3.0', '3.1', '3.2', '3.3' ]
+        ruby: [ '3.1', '3.2', '3.3' ]
     name: Ruby v${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also, generated documentation by YARD is available.
 - https://rubydoc.info/gems/line-bot-api
 
 ## Requirements
-This library requires Ruby 3.0 or later.
+This library requires Ruby 3.1 or later.
 
 ## Installation
 


### PR DESCRIPTION
Ruby 3.0 got EOL. https://endoflife.date/ruby