### PR TITLE
feat: Support LINE notification messages API

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -1207,6 +1207,36 @@ module Line
         get(endpoint, endpoint_path, credentials)
       end
 
+      # Send a LINE notification message by specifying the user's phone number.
+      #
+      # @param hashed_phone_number [String] Phone number that has been normalized.
+      # @param messages [Hash, Array] Message Objects.
+      # @param headers [Hash] HTTP Headers.
+      # @param payload [Hash] Additional request body.
+      #
+      # @return [Net::HTTPResponse]
+      def push_pnp(hashed_phone_number, messages, headers: {}, payload: {})
+        channel_token_required
+
+        messages = [messages] if messages.is_a?(Hash)
+
+        endpoint_path = '/bot/pnp/push'
+        payload = payload.merge({ to: hashed_phone_number, messages: messages }).to_json
+        post(oauth_endpoint, endpoint_path, payload, credentials.merge(headers))
+      end
+
+      # Get the number of LINE notification messages sent using the /bot/pnp/push endpoint.
+      #
+      # @param date [String] Date the messages were sent (format: yyyyMMdd).
+      #
+      # @return [Net::HTTPResponse]
+      def get_message_delivery_pnp(date)
+        channel_token_required
+
+        endpoint_path = "/bot/message/delivery/pnp?date=#{date}"
+        get(endpoint, endpoint_path, credentials)
+      end
+
       # Fetch data, get content of specified URL.
       #
       # @param endpoint_base [String]

--- a/spec/line/bot/client_line_notification_spec.rb
+++ b/spec/line/bot/client_line_notification_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+DELIVERY_RESULT_CONTENT = <<~"EOS"
+{
+  "status": "ready",
+  "success": 3
+}
+EOS
+
+describe Line::Bot::Client do
+  describe '#push_pnp' do
+    before do
+      uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_OAUTH_ENDPOINT + '/bot/pnp/push'
+      stub_request(:post, uri_template).to_return { |request| { body: '{}', status: 200 } }
+    end
+
+    let(:client)  do
+      Line::Bot::Client.new do |config|
+        config.channel_token = 'channel_token'
+      end
+    end
+    let(:phone_number) { "+818000001234" }
+    let(:hashed_phone_number) { Digest::SHA256.hexdigest(phone_number) }
+    let(:x_line_delivery_tag) { 'd41e0ad70dddfeb68f149ad6fc61574b9c5780ab7bcb2fba5517771ffbb2409c' }
+    let(:message) do
+      {
+        type: 'text',
+        text: 'Hello, world'
+      }
+    end
+
+    context 'normal scenario' do
+      it 'pushes the message' do
+        response = client.push_pnp(hashed_phone_number, message)
+
+        expect(response).to be_a(Net::HTTPOK)
+        expect(response.body).to eq('{}')
+      end
+    end
+
+    context 'with X-Line-Delivery-Tag header' do
+      it 'pushes the message with additional header' do
+        response = client.push_pnp(hashed_phone_number, message, headers: { 'X-Line-Delivery-Tag' => x_line_delivery_tag })
+
+        expect(response).to be_a(Net::HTTPOK)
+        expect(response.body).to eq('{}')
+      end
+    end
+  end
+
+  describe '#get_message_delivery_pnp' do
+    before do
+      uri_template = Addressable::Template.new Line::Bot::API::DEFAULT_ENDPOINT + '/bot/message/delivery/pnp?date={date}'
+      stub_request(:get, uri_template).to_return { |request| { body: DELIVERY_RESULT_CONTENT, status: 200 } }
+    end
+
+    let(:client)  do
+      Line::Bot::Client.new do |config|
+        config.channel_token = 'channel_token'
+      end
+    end
+
+    it 'gets the delivery result' do
+      response = client.get_message_delivery_pnp('20240524')
+
+      expect(response).to be_a(Net::HTTPOK)
+      expect(response.body).to eq(DELIVERY_RESULT_CONTENT)
+    end
+  end
+end


### PR DESCRIPTION
This PR attempts to support the [LINE notification messages API](https://developers.line.biz/en/reference/partner-docs/#line-notification-messages-api).

 - [x] Send LINE notification message using phone number
 - [x] Get number of sent LINE notification messages
