### PR TITLE
Open issue when release failed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,6 +31,7 @@ jobs:
             VERSION=${{ github.event.release.tag_name }}
           fi
           VERSION=${VERSION#v}
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
 
           sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" lib/line/bot/api/version.rb
           
@@ -43,3 +44,21 @@ jobs:
           git add lib/line/bot/api/version.rb
           git commit -m "Set version to $VERSION"
       - uses: rubygems/release-gem@v1
+
+      - name: Create GitHub Issue on Failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const version = process.env.VERSION;
+            const issueTitle = `Release job for ${version} failed`;
+            const issueBody = `The release job failed. Please check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details.`;
+            const assignees = [context.actor];
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: issueTitle,
+              body: issueBody,
+              assignees
+            });


### PR DESCRIPTION
When release job fails, we may not realize the issue. Let's open issue to notify us the release job failed.

I've tested this change and it opened an issue like this.
- title contains the release(d) version
- actor is assigned
- description contains failed job url
![image](https://github.com/user-attachments/assets/d2f0464d-2d0f-413a-b0df-da7966289e7e)
