### PR TITLE
Fix endpoint path to resolve Socket::ResolutionError

### DIFF
--- a/lib/line/bot/client.rb
+++ b/lib/line/bot/client.rb
@@ -1189,7 +1189,7 @@ module Line
         to = [to] if to.is_a?(String)
         messages = [messages] if messages.is_a?(Hash)
 
-        endpoint_path = 'bot/ad/multicast/phone'
+        endpoint_path = '/bot/ad/multicast/phone'
         payload = payload.merge({ to: to, messages: messages }).to_json
         post(oauth_endpoint, endpoint_path, payload, credentials.merge(headers))
       end


### PR DESCRIPTION
This PR fixes a DNS resolution error that occurs due to an incorrect endpoint path in the line-bot-sdk-ruby. The error message looks like this:

```
2025-01-05 22:50:56 - Socket::ResolutionError - Failed to open TCP connection to api.line.mebot:443 (getaddrinfo: nodename nor servname provided, or not known) (Socket::ResolutionError)
```

Please refer to https://github.com/line/line-bot-sdk-ruby/issues/357 for more details. 🙂 