### PR TITLE
Pin commit hash of github actions to avoid supply chain attacks

### DIFF
--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run EoL & NewRelease check
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const checkEolAndNewReleases = require('.github/scripts/check-eol-newrelease.cjs');

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 0

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -43,10 +43,10 @@ jobs:
     needs: validate-input
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch Latest Release
         id: get-latest-release
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const latestRelease = await github.rest.repos.getLatestRelease({
@@ -62,7 +62,7 @@ jobs:
 
       - name: Calculate New Version
         id: calculate-version
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const latestTag = '${{ steps.get-latest-release.outputs.latest_tag }}';
@@ -83,7 +83,7 @@ jobs:
 
       - name: Generate Release Notes
         id: generate-release-notes
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { data: releaseNotes } = await github.rest.repos.generateReleaseNotes({

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,8 @@ jobs:
       contents: write # IMPORTANT: this permission is required for `rake release` to push the release tag
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
         with:
           bundler-cache: true
           ruby-version: 3.3
@@ -43,11 +43,11 @@ jobs:
 
           git add lib/line/bot/api/version.rb
           git commit -m "Set version to $VERSION"
-      - uses: rubygems/release-gem@v1
+      - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1
 
       - name: Create GitHub Issue on Failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { owner, repo } = context.repo;

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,3 +22,12 @@ jobs:
     - run: bundle install
     - run: bundle exec rubocop
     - run: bundle exec rspec
+
+  pinact:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Run pinact
+        uses: suzuki-shunsuke/pinact-action@a6896d13d22e2bf108a78b0c52d3f867c1f41b34 # v0.2.1
+        with:
+          skip_push: "true"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,8 +14,8 @@ jobs:
         ruby: [ '3.1', '3.2', '3.3' ]
     name: Ruby v${{ matrix.ruby }}
     steps:
-    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-    - uses: ruby/setup-ruby@v1
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f # v1.227.0
       with:
         ruby-version: ${{ matrix.ruby }}
     - run: gem install bundler

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,8 @@ jobs:
 
   pinact:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run pinact

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:base",
+    "helpers:pinGitHubActionDigestsToSemver"
   ],
   "automerge": true,
   "platformAutomerge": true,


### PR DESCRIPTION
## Changes
To avoid supply chain attacks, specify actions in GitHub Actions workflows using commit hashes instead of version numbers. Pinact-action will fail the CI job if this is not done. Renovate already supports updates in the commit hash state, so there is no issue.

## References
- https://github.com/suzuki-shunsuke/pinact-action
  - does pinact-action verify the checksum of the version of aqua it is using? Yes!: 
- https://github.com/suzuki-shunsuke/pinact

## Other repositories
- line/line-bot-sdk-python https://github.com/line/line-bot-sdk-python/pull/772
- line/line-bot-sdk-php https://github.com/line/line-bot-sdk-php/pull/680
- line/line-bot-sdk-nodejs https://github.com/line/line-bot-sdk-nodejs/pull/1201
- line/line-bot-sdk-java https://github.com/line/line-bot-sdk-java/pull/1576
- line/line-bot-sdk-go https://github.com/line/line-bot-sdk-go/pull/555
- line/line-bot-sdk-ruby https://github.com/line/line-bot-sdk-ruby/pull/405
- line/line-openapi https://github.com/line/line-openapi/pull/90