### PR TITLE
Grant minimum permissions to github acitons workflow jobs

### DIFF
--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   check-eol-newrelease:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/check-eol-newrelease.yml
+++ b/.github/workflows/check-eol-newrelease.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+    if: github.repository == 'line/line-bot-sdk-ruby'
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    if: github.repository == 'line/line-bot-sdk-ruby'
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -26,6 +26,7 @@ on:
 jobs:
   validate-input:
     runs-on: ubuntu-latest
+    permissions: {}
     steps:
       - name: Validate Acknowledgement
         if: ${{ github.event.inputs.acknowledge_draft != 'Yes' }}
@@ -41,7 +42,8 @@ jobs:
   create-draft-release:
     runs-on: ubuntu-latest
     needs: validate-input
-
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Fetch Latest Release

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         # https://www.ruby-lang.org/en/downloads/branches/


### PR DESCRIPTION
## Changes
Granting the minimum necessary permissions is always a good practice. There might be cases where permissions are insufficient, but since errors are very clear, I believe we can add them when a failure occurs.

After merging, I will change the default of the GITHUB_ACTIONS token from read + write to read only. Then, I will run as many workflows as possible (including publish) to verify their operation.

reference: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token#overview