### PR TITLE
Run tests even if the file name suffix is not '_spec.rb’

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,4 @@
 --format documentation
 --color
+--pattern 'spec/**/*.rb'
+--exclude-pattern 'spec/fixtures/**/*.rb'


### PR DESCRIPTION
By default, RSpec does not run tests if the file name suffix is not "_spec.rb". To prevent mistakes, I think it's best to explicitly run all tests. In fact, spec/api/** had not been executed for a long time.