### PR TITLE
Use `FILE` Instead of `file` for RBS Validation

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -25,6 +25,18 @@ jobs:
     - run: bundle exec rubocop
     - run: bundle exec rspec
 
+  rbs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ruby/setup-ruby@354a1ad156761f5ee2b7b13fa8e09943a5e8d252 # v1.229.0
+        with:
+          ruby-version: '3.2'
+      - run: gem install rbs
+      - run: rbs -I sig validate
+
   pinact:
     runs-on: ubuntu-latest
     permissions:

--- a/README_v2.md
+++ b/README_v2.md
@@ -182,7 +182,7 @@ main
 See the [examples](examples/v2) directory for more examples.
 
 ### RBS
-This library provides RBS files for type checking.\
+This library provides [RBS](https://github.com/ruby/rbs) files for type checking.\
 You can code with type support in the corresponding IDE or editor.
 
 ## Media

--- a/generator/src/main/resources/line-bot-sdk-ruby-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-generator/api.pebble
@@ -1,7 +1,7 @@
 {# @pebvariable name="operations" type="org.openapitools.codegen.model.OperationMap" -#}
 {# @pebvariable name="authMethods" type="java.util.ArrayList<org.openapitools.codegen.CodegenSecurity>" -#}
 {# @pebvariable name="packageName" type="String" #}
-{%- include "./license-info.pebble" %}
+{%- include "./license.pebble" %}
 require 'json'
 
 require 'line/bot/v2/http_client'

--- a/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
@@ -38,7 +38,7 @@ module Line
             {%- for param in op.allParams %}
             {{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
             {% endfor %}
-          ) -> [({% for response in op.responses %}{{ response.baseType == 'object' or response.baseType == null ? 'String?' : response.baseType }}{{ loop.last ? '' : '|' }}{% endfor %}), Integer, Hash[String, String]]
+          ) -> [({% for response in op.responses %}{{ response.baseType == 'object' or response.baseType == null ? 'String?' : response.dataType }}{{ loop.last ? '' : '|' }}{% endfor %}), Integer, Hash[String, String]]
 
           # {{ op.notes }}
           #
@@ -61,7 +61,7 @@ module Line
             {%- for param in op.allParams %}
             {{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
             {% endfor %}
-          ) -> ({% for response in op.responses %}{{ response.baseType == 'object' or response.baseType == null ? 'String?' : response.baseType }}{{ loop.last ? '' : '|' }}{% endfor %}){% endfor %}
+          ) -> ({% for response in op.responses %}{{ response.baseType == 'object' or response.baseType == null ? 'String?' : response.dataType }}{{ loop.last ? '' : '|' }}{% endfor %}){% endfor %}
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
+++ b/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
@@ -24,7 +24,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-content
           def get_message_content_with_http_info: (
             message_id: String
-          ) -> [(file), Integer, Hash[String, String]]
+          ) -> [(File), Integer, Hash[String, String]]
 
           # Download image, video, and audio data sent from users.
           #
@@ -32,7 +32,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-content
           def get_message_content: (
             message_id: String
-          ) -> (file)
+          ) -> (File)
 
           # Get a preview image of the image or video
           #
@@ -40,7 +40,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-image-or-video-preview
           def get_message_content_preview_with_http_info: (
             message_id: String
-          ) -> [(file), Integer, Hash[String, String]]
+          ) -> [(File), Integer, Hash[String, String]]
 
           # Get a preview image of the image or video
           #
@@ -48,7 +48,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-image-or-video-preview
           def get_message_content_preview: (
             message_id: String
-          ) -> (file)
+          ) -> (File)
 
           # Verify the preparation status of a video or audio for getting
           #
@@ -72,7 +72,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#download-rich-menu-image
           def get_rich_menu_image_with_http_info: (
             rich_menu_id: String
-          ) -> [(file), Integer, Hash[String, String]]
+          ) -> [(File), Integer, Hash[String, String]]
 
           # Download rich menu image.
           #
@@ -80,7 +80,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#download-rich-menu-image
           def get_rich_menu_image: (
             rich_menu_id: String
-          ) -> (file)
+          ) -> (File)
 
           # Upload rich menu image
           #


### PR DESCRIPTION
This PR updates the RBS validation process by changing the parameter from `file` to `FILE`, resolving the issue of the file not being found during the execution of `rbs validate`.

Additionally, this change adds the rbs command as a part of our CI workflow.

resolve https://github.com/line/line-bot-sdk-ruby/issues/424