### PR TITLE
Add spec for capability for unknown message type in webhook parsing

### DIFF
--- a/spec/line/bot/v2/webhook_parser_spec.rb
+++ b/spec/line/bot/v2/webhook_parser_spec.rb
@@ -45,6 +45,63 @@ describe Line::Bot::V2::WebhookParser do
       end
     end
 
+    context 'with an unknown message type' do
+      let(:webhook) do
+        <<~JSON
+          {
+            "destination": "xxxxxxxxxx",
+            "events": [
+              {
+                "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+                "type": "message",
+                "mode": "active",
+                "timestamp": 1462629479859,
+                "source": {
+                  "type": "group",
+                  "groupId": "Ca56f94637c...",
+                  "userId": "U4af4980629..."
+                },
+                "webhookEventId": "01FZ74A0TDDPYRVKNK77XKC3ZR",
+                "deliveryContext": {
+                  "isRedelivery": false
+                },
+                "message": {
+                  "id": "444573844083572737",
+                  "type": "hoge",
+                  "quoteToken": "q3Plxr4AgKd...",
+                  "text": "Test Message"
+                }
+              }
+            ]
+          }
+        JSON
+      end
+
+      it 'parses the webhook as a text MessageEvent' do
+        events = parser.parse(webhook, signature)
+        expect(events).not_to be_empty
+
+        event = events.first
+        expect(event).to be_a(Line::Bot::V2::Webhook::MessageEvent)
+        expect(event.reply_token).to eq('nHuyWiB7yP5Zw52FIkcQobQuGDXCTA')
+        expect(event.type).to eq('message')
+        expect(event.mode).to eq('active')
+        expect(event.timestamp).to eq(1462629479859)
+        expect(event.source).to be_a(Line::Bot::V2::Webhook::GroupSource)
+        expect(event.source.type).to eq('group')
+        expect(event.source.group_id).to eq('Ca56f94637c...')
+        expect(event.source.user_id).to eq('U4af4980629...')
+        expect(event.webhook_event_id).to eq('01FZ74A0TDDPYRVKNK77XKC3ZR')
+        expect(event.delivery_context).to be_a(Line::Bot::V2::Webhook::DeliveryContext)
+        expect(event.delivery_context.is_redelivery).to be false
+        expect(event.message).to be_a(OpenStruct)
+        expect(event.message.id).to eq('444573844083572737')
+        expect(event.message.type).to eq('hoge')
+        expect(event.message.quote_token).to eq('q3Plxr4AgKd...')
+        expect(event.message.text).to eq('Test Message')
+      end
+    end
+
     context 'with a text MessageEvent' do
       let(:webhook) do
         <<~JSON


### PR DESCRIPTION
Add a spec to make sure that parsing does not fail if there is a `type` undefined in the SDK inside the webhook when the SDK is not up-to-date.
The webhook type itself is already tested, and this PR further tests it with an internally nested message type.