### PR TITLE
Reintroduce Timing-Safe Signature Verification in v2 Webhook Parser

### DIFF
--- a/sig/line/bot/v2/webhook_parser.rbs
+++ b/sig/line/bot/v2/webhook_parser.rbs
@@ -8,6 +8,10 @@ module Line
 
         private
 
+        def variable_secure_compare: (a: String, b: String) -> bool
+
+        def secure_compare: (a: String, b: String) -> bool
+
         def verify_signature: (body: String, signature: String) -> bool
 
         def create_instance: (untyped klass, Hash[Symbol, untyped] attributes) -> untyped


### PR DESCRIPTION
Resolve https://github.com/line/line-bot-sdk-ruby/issues/428

In v1, we had a constant-time signature comparison to mitigate timing attacks.
- https://github.com/line/line-bot-sdk-ruby/blob/a6db291b252b13116b67f9b3621f73d3694b35bc/lib/line/bot/v1/client.rb#L1654-L1691

In v2(before release), this check was removed. This patch reintroduces timing-safe verification, ensuring that the request body and the `x-line-signature` header are validated without leaking timing information.