### PR TITLE
Make handleable invalid fields

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
@@ -26,12 +26,18 @@ module Line
           {%- endfor %}
 
           def initialize({% for property in model.model.vars %}{% if model.model.vendorExtensions.get("x-selector").propertyName != property.name or packageName == 'webhook' %}
-            {{ property.name }}:{% if property.defaultValue == null %}{{ property.required ? '' : ' nil'  }}{% else %}{{ ' ' + property.defaultValue }}{% endif %}{{ loop.last ? '' : ',' -}}{% endif %}{% endfor %}
+            {{ property.name }}:{% if property.defaultValue == null %}{{ property.required ? '' : ' nil'  }}{% else %}{{ ' ' + property.defaultValue }}{% endif %},{% endif %}{% endfor %}
+            **dynamic_attributes
           )
             {% if model.model.vendorExtensions.get("x-selector") != null %}@{{model.model.vendorExtensions.get("x-selector").propertyName}} = "{{model.model.vendorExtensions.get("x-selector").mappingName}}"{% endif -%}
             {%- for property in model.model.vars %}
             {% if model.model.vendorExtensions.get("x-selector").propertyName != property.name %}@{{ property.name }} = {{ property.name }}{% endif -%}
             {% endfor %}
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :kids # Array of channel access token key IDs.
 
           def initialize(
-            kids:
+            kids:,
+            **dynamic_attributes
           )
             
             @kids = kids
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/error_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/error_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             error: nil,
-            error_description: nil
+            error_description: nil,
+            **dynamic_attributes
           )
             
             @error = error
             @error_description = error_description
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rb
@@ -23,13 +23,19 @@ module Line
             access_token:,
             expires_in:,
             token_type: 'Bearer',
-            key_id:
+            key_id:,
+            **dynamic_attributes
           )
             
             @access_token = access_token
             @expires_in = expires_in
             @token_type = token_type
             @key_id = key_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             access_token:,
             expires_in:,
-            token_type: 'Bearer'
+            token_type: 'Bearer',
+            **dynamic_attributes
           )
             
             @access_token = access_token
             @expires_in = expires_in
             @token_type = token_type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             access_token:,
             expires_in:,
-            token_type: 'Bearer'
+            token_type: 'Bearer',
+            **dynamic_attributes
           )
             
             @access_token = access_token
             @expires_in = expires_in
             @token_type = token_type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             client_id:,
             expires_in:,
-            scope: nil
+            scope: nil,
+            **dynamic_attributes
           )
             
             @client_id = client_id
             @expires_in = expires_in
             @scope = scope
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/age_tile.rb
+++ b/lib/line/bot/v2/insight/model/age_tile.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             age: nil,
-            percentage: nil
+            percentage: nil,
+            **dynamic_attributes
           )
             
             @age = age
             @percentage = percentage
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/app_type_tile.rb
+++ b/lib/line/bot/v2/insight/model/app_type_tile.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             app_type: nil,
-            percentage: nil
+            percentage: nil,
+            **dynamic_attributes
           )
             
             @app_type = app_type
             @percentage = percentage
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/area_tile.rb
+++ b/lib/line/bot/v2/insight/model/area_tile.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             area: nil,
-            percentage: nil
+            percentage: nil,
+            **dynamic_attributes
           )
             
             @area = area
             @percentage = percentage
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/error_detail.rb
+++ b/lib/line/bot/v2/insight/model/error_detail.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             message: nil,
-            property: nil
+            property: nil,
+            **dynamic_attributes
           )
             
             @message = message
             @property = property
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/error_response.rb
+++ b/lib/line/bot/v2/insight/model/error_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             message:,
-            details: nil
+            details: nil,
+            **dynamic_attributes
           )
             
             @message = message
             @details = details
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/gender_tile.rb
+++ b/lib/line/bot/v2/insight/model/gender_tile.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             gender: nil,
-            percentage: nil
+            percentage: nil,
+            **dynamic_attributes
           )
             
             @gender = gender
             @percentage = percentage
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_friends_demographics_response.rb
+++ b/lib/line/bot/v2/insight/model/get_friends_demographics_response.rb
@@ -27,7 +27,8 @@ module Line
             ages: nil,
             areas: nil,
             app_types: nil,
-            subscription_periods: nil
+            subscription_periods: nil,
+            **dynamic_attributes
           )
             
             @available = available
@@ -36,6 +37,11 @@ module Line
             @areas = areas
             @app_types = app_types
             @subscription_periods = subscription_periods
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             overview: nil,
             messages: nil,
-            clicks: nil
+            clicks: nil,
+            **dynamic_attributes
           )
             
             @overview = overview
             @messages = messages
             @clicks = clicks
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response_click.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_click.rb
@@ -23,7 +23,8 @@ module Line
             url: nil,
             click: nil,
             unique_click: nil,
-            unique_click_of_request: nil
+            unique_click_of_request: nil,
+            **dynamic_attributes
           )
             
             @seq = seq
@@ -31,6 +32,11 @@ module Line
             @click = click
             @unique_click = unique_click
             @unique_click_of_request = unique_click_of_request
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response_message.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_message.rb
@@ -37,7 +37,8 @@ module Line
             unique_media_played25_percent: nil,
             unique_media_played50_percent: nil,
             unique_media_played75_percent: nil,
-            unique_media_played100_percent: nil
+            unique_media_played100_percent: nil,
+            **dynamic_attributes
           )
             
             @seq = seq
@@ -52,6 +53,11 @@ module Line
             @unique_media_played50_percent = unique_media_played50_percent
             @unique_media_played75_percent = unique_media_played75_percent
             @unique_media_played100_percent = unique_media_played100_percent
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response_overview.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_overview.rb
@@ -28,7 +28,8 @@ module Line
             unique_impression: nil,
             unique_click: nil,
             unique_media_played: nil,
-            unique_media_played100_percent: nil
+            unique_media_played100_percent: nil,
+            **dynamic_attributes
           )
             
             @request_id = request_id
@@ -38,6 +39,11 @@ module Line
             @unique_click = unique_click
             @unique_media_played = unique_media_played
             @unique_media_played100_percent = unique_media_played100_percent
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_number_of_followers_response.rb
+++ b/lib/line/bot/v2/insight/model/get_number_of_followers_response.rb
@@ -23,13 +23,19 @@ module Line
             status: nil,
             followers: nil,
             targeted_reaches: nil,
-            blocks: nil
+            blocks: nil,
+            **dynamic_attributes
           )
             
             @status = status
             @followers = followers
             @targeted_reaches = targeted_reaches
             @blocks = blocks
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rb
+++ b/lib/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rb
@@ -37,7 +37,8 @@ module Line
             api_push: nil,
             api_multicast: nil,
             api_narrowcast: nil,
-            api_reply: nil
+            api_reply: nil,
+            **dynamic_attributes
           )
             
             @status = status
@@ -51,6 +52,11 @@ module Line
             @api_multicast = api_multicast
             @api_narrowcast = api_narrowcast
             @api_reply = api_reply
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             overview:,
             messages:,
-            clicks:
+            clicks:,
+            **dynamic_attributes
           )
             
             @overview = overview
             @messages = messages
             @clicks = clicks
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rb
@@ -24,7 +24,8 @@ module Line
             url:,
             click: nil,
             unique_click: nil,
-            unique_click_of_request: nil
+            unique_click_of_request: nil,
+            **dynamic_attributes
           )
             
             @seq = seq
@@ -32,6 +33,11 @@ module Line
             @click = click
             @unique_click = unique_click
             @unique_click_of_request = unique_click_of_request
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rb
@@ -40,7 +40,8 @@ module Line
             unique_media_played25_percent: nil,
             unique_media_played50_percent: nil,
             unique_media_played75_percent: nil,
-            unique_media_played100_percent: nil
+            unique_media_played100_percent: nil,
+            **dynamic_attributes
           )
             
             @seq = seq
@@ -56,6 +57,11 @@ module Line
             @unique_media_played50_percent = unique_media_played50_percent
             @unique_media_played75_percent = unique_media_played75_percent
             @unique_media_played100_percent = unique_media_played100_percent
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rb
@@ -23,13 +23,19 @@ module Line
             unique_impression: nil,
             unique_click: nil,
             unique_media_played: nil,
-            unique_media_played100_percent: nil
+            unique_media_played100_percent: nil,
+            **dynamic_attributes
           )
             
             @unique_impression = unique_impression
             @unique_click = unique_click
             @unique_media_played = unique_media_played
             @unique_media_played100_percent = unique_media_played100_percent
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/subscription_period_tile.rb
+++ b/lib/line/bot/v2/insight/model/subscription_period_tile.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             subscription_period: nil,
-            percentage: nil
+            percentage: nil,
+            **dynamic_attributes
           )
             
             @subscription_period = subscription_period
             @percentage = percentage
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/add_liff_app_request.rb
+++ b/lib/line/bot/v2/liff/model/add_liff_app_request.rb
@@ -26,7 +26,8 @@ module Line
             features: nil,
             permanent_link_pattern: nil,
             scope: nil,
-            bot_prompt: nil
+            bot_prompt: nil,
+            **dynamic_attributes
           )
             
             @view = view
@@ -35,6 +36,11 @@ module Line
             @permanent_link_pattern = permanent_link_pattern
             @scope = scope
             @bot_prompt = bot_prompt
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/add_liff_app_response.rb
+++ b/lib/line/bot/v2/liff/model/add_liff_app_response.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :liff_id
 
           def initialize(
-            liff_id:
+            liff_id:,
+            **dynamic_attributes
           )
             
             @liff_id = liff_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/get_all_liff_apps_response.rb
+++ b/lib/line/bot/v2/liff/model/get_all_liff_apps_response.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :apps
 
           def initialize(
-            apps: nil
+            apps: nil,
+            **dynamic_attributes
           )
             
             @apps = apps
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_app.rb
+++ b/lib/line/bot/v2/liff/model/liff_app.rb
@@ -27,7 +27,8 @@ module Line
             features: nil,
             permanent_link_pattern: nil,
             scope: nil,
-            bot_prompt: nil
+            bot_prompt: nil,
+            **dynamic_attributes
           )
             
             @liff_id = liff_id
@@ -37,6 +38,11 @@ module Line
             @permanent_link_pattern = permanent_link_pattern
             @scope = scope
             @bot_prompt = bot_prompt
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_bot_prompt.rb
+++ b/lib/line/bot/v2/liff/model/liff_bot_prompt.rb
@@ -15,8 +15,14 @@ module Line
         class LiffBotPrompt
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_features.rb
+++ b/lib/line/bot/v2/liff/model/liff_features.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             ble: nil,
-            qr_code: false
+            qr_code: false,
+            **dynamic_attributes
           )
             
             @ble = ble
             @qr_code = qr_code
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_scope.rb
+++ b/lib/line/bot/v2/liff/model/liff_scope.rb
@@ -15,8 +15,14 @@ module Line
         class LiffScope
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_view.rb
+++ b/lib/line/bot/v2/liff/model/liff_view.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             type:,
             url:,
-            module_mode: nil
+            module_mode: nil,
+            **dynamic_attributes
           )
             
             @type = type
             @url = url
             @module_mode = module_mode
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/update_liff_app_request.rb
+++ b/lib/line/bot/v2/liff/model/update_liff_app_request.rb
@@ -26,7 +26,8 @@ module Line
             features: nil,
             permanent_link_pattern: nil,
             scope: nil,
-            bot_prompt: nil
+            bot_prompt: nil,
+            **dynamic_attributes
           )
             
             @view = view
@@ -35,6 +36,11 @@ module Line
             @permanent_link_pattern = permanent_link_pattern
             @scope = scope
             @bot_prompt = bot_prompt
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/update_liff_view.rb
+++ b/lib/line/bot/v2/liff/model/update_liff_view.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             type: nil,
             url: nil,
-            module_mode: nil
+            module_mode: nil,
+            **dynamic_attributes
           )
             
             @type = type
             @url = url
             @module_mode = module_mode
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/adaccount.rb
+++ b/lib/line/bot/v2/manage_audience/model/adaccount.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :name # Ad account name.
 
           def initialize(
-            name: nil
+            name: nil,
+            **dynamic_attributes
           )
             
             @name = name
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             audience_group_id: nil,
             upload_description: nil,
-            audiences: nil
+            audiences: nil,
+            **dynamic_attributes
           )
             
             @audience_group_id = audience_group_id
             @upload_description = upload_description
             @audiences = audiences
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :id # A user ID or IFA. You can specify an empty array.
 
           def initialize(
-            id: nil
+            id: nil,
+            **dynamic_attributes
           )
             
             @id = id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group.rb
@@ -38,7 +38,8 @@ module Line
             click_url: nil,
             is_ifa_audience: nil,
             permission: nil,
-            create_route: nil
+            create_route: nil,
+            **dynamic_attributes
           )
             
             @audience_group_id = audience_group_id
@@ -53,6 +54,11 @@ module Line
             @is_ifa_audience = is_ifa_audience
             @permission = permission
             @create_route = create_route
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_authority_level.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_authority_level.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupAuthorityLevel
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_create_route.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_create_route.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupCreateRoute
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_failed_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_failed_type.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupFailedType
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job.rb
@@ -31,7 +31,8 @@ module Line
             job_status: nil,
             failed_type: nil,
             audience_count: nil,
-            created: nil
+            created: nil,
+            **dynamic_attributes
           )
             
             @audience_group_job_id = audience_group_job_id
@@ -42,6 +43,11 @@ module Line
             @failed_type = failed_type
             @audience_count = audience_count
             @created = created
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job_failed_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job_failed_type.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupJobFailedType
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job_status.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job_status.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupJobStatus
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job_type.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupJobType
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_permission.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_permission.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupPermission
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_status.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_status.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupStatus
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_type.rb
@@ -15,8 +15,14 @@ module Line
         class AudienceGroupType
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_audience_group_request.rb
@@ -23,13 +23,19 @@ module Line
             description: nil,
             is_ifa_audience: nil,
             upload_description: nil,
-            audiences: nil
+            audiences: nil,
+            **dynamic_attributes
           )
             
             @description = description
             @is_ifa_audience = is_ifa_audience
             @upload_description = upload_description
             @audiences = audiences
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_audience_group_response.rb
@@ -31,7 +31,8 @@ module Line
             created: nil,
             permission: nil,
             expire_timestamp: nil,
-            is_ifa_audience: nil
+            is_ifa_audience: nil,
+            **dynamic_attributes
           )
             
             @audience_group_id = audience_group_id
@@ -42,6 +43,11 @@ module Line
             @permission = permission
             @expire_timestamp = expire_timestamp
             @is_ifa_audience = is_ifa_audience
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             description: nil,
             request_id: nil,
-            click_url: nil
+            click_url: nil,
+            **dynamic_attributes
           )
             
             @description = description
             @request_id = request_id
             @click_url = click_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rb
@@ -35,7 +35,8 @@ module Line
             create_route: nil,
             permission: nil,
             expire_timestamp: nil,
-            is_ifa_audience: false
+            is_ifa_audience: false,
+            **dynamic_attributes
           )
             
             @audience_group_id = audience_group_id
@@ -48,6 +49,11 @@ module Line
             @permission = permission
             @expire_timestamp = expire_timestamp
             @is_ifa_audience = is_ifa_audience
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             description: nil,
-            request_id: nil
+            request_id: nil,
+            **dynamic_attributes
           )
             
             @description = description
             @request_id = request_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rb
@@ -25,7 +25,8 @@ module Line
             type: nil,
             description: nil,
             created: nil,
-            request_id: nil
+            request_id: nil,
+            **dynamic_attributes
           )
             
             @audience_group_id = audience_group_id
@@ -33,6 +34,11 @@ module Line
             @description = description
             @created = created
             @request_id = request_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/detailed_owner.rb
+++ b/lib/line/bot/v2/manage_audience/model/detailed_owner.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             service_type: nil,
             id: nil,
-            name: nil
+            name: nil,
+            **dynamic_attributes
           )
             
             @service_type = service_type
             @id = id
             @name = name
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/error_detail.rb
+++ b/lib/line/bot/v2/manage_audience/model/error_detail.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             message: nil,
-            property: nil
+            property: nil,
+            **dynamic_attributes
           )
             
             @message = message
             @property = property
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/error_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/error_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             message:,
-            details: nil
+            details: nil,
+            **dynamic_attributes
           )
             
             @message = message
             @details = details
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_audience_data_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_audience_data_response.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             audience_group: nil,
             jobs: nil,
-            adaccount: nil
+            adaccount: nil,
+            **dynamic_attributes
           )
             
             @audience_group = audience_group
             @jobs = jobs
             @adaccount = adaccount
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_audience_group_authority_level_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_audience_group_authority_level_response.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :authority_level
 
           def initialize(
-            authority_level: nil
+            authority_level: nil,
+            **dynamic_attributes
           )
             
             @authority_level = authority_level
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_audience_groups_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_audience_groups_response.rb
@@ -27,7 +27,8 @@ module Line
             total_count: nil,
             read_write_audience_group_total_count: nil,
             page: nil,
-            size: nil
+            size: nil,
+            **dynamic_attributes
           )
             
             @audience_groups = audience_groups
@@ -36,6 +37,11 @@ module Line
             @read_write_audience_group_total_count = read_write_audience_group_total_count
             @page = page
             @size = size
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             audience_group: nil,
             jobs: nil,
-            owner: nil
+            owner: nil,
+            **dynamic_attributes
           )
             
             @audience_group = audience_group
             @jobs = jobs
             @owner = owner
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_shared_audience_groups_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_shared_audience_groups_response.rb
@@ -27,7 +27,8 @@ module Line
             total_count: nil,
             read_write_audience_group_total_count: nil,
             page: nil,
-            size: nil
+            size: nil,
+            **dynamic_attributes
           )
             
             @audience_groups = audience_groups
@@ -36,6 +37,11 @@ module Line
             @read_write_audience_group_total_count = read_write_audience_group_total_count
             @page = page
             @size = size
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/update_audience_group_authority_level_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/update_audience_group_authority_level_request.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :authority_level
 
           def initialize(
-            authority_level: nil
+            authority_level: nil,
+            **dynamic_attributes
           )
             
             @authority_level = authority_level
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/update_audience_group_description_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/update_audience_group_description_request.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :description # The audience's name. This is case-insensitive, meaning AUDIENCE and audience are considered identical. Max character limit: 120 
 
           def initialize(
-            description: nil
+            description: nil,
+            **dynamic_attributes
           )
             
             @description = description
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/action.rb
+++ b/lib/line/bot/v2/messaging_api/model/action.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             type: nil,
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             
             @type = type
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/age_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/age_demographic.rb
@@ -14,8 +14,14 @@ module Line
         class AgeDemographic
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/age_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/age_demographic_filter.rb
@@ -20,12 +20,18 @@ module Line
 
           def initialize(
             gte: nil,
-            lt: nil
+            lt: nil,
+            **dynamic_attributes
           )
             @type = "age"
             
             @gte = gte
             @lt = lt
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/all_mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/all_mention_target.rb
@@ -18,9 +18,15 @@ module Line
           attr_reader :type # Target to be mentioned
 
           def initialize(
+            **dynamic_attributes
           )
             @type = "all"
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/alt_uri.rb
+++ b/lib/line/bot/v2/messaging_api/model/alt_uri.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :desktop
 
           def initialize(
-            desktop: nil
+            desktop: nil,
+            **dynamic_attributes
           )
             
             @desktop = desktop
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/app_type_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/app_type_demographic.rb
@@ -14,8 +14,14 @@ module Line
         class AppTypeDemographic
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :one_of
 
           def initialize(
-            one_of: nil
+            one_of: nil,
+            **dynamic_attributes
           )
             @type = "appType"
             
             @one_of = one_of
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/area_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/area_demographic.rb
@@ -15,8 +15,14 @@ module Line
         class AreaDemographic
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :one_of
 
           def initialize(
-            one_of: nil
+            one_of: nil,
+            **dynamic_attributes
           )
             @type = "area"
             
             @one_of = one_of
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/audience_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/audience_recipient.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :audience_group_id
 
           def initialize(
-            audience_group_id: nil
+            audience_group_id: nil,
+            **dynamic_attributes
           )
             @type = "audience"
             
             @audience_group_id = audience_group_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/audio_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/audio_message.rb
@@ -25,7 +25,8 @@ module Line
             quick_reply: nil,
             sender: nil,
             original_content_url:,
-            duration:
+            duration:,
+            **dynamic_attributes
           )
             @type = "audio"
             
@@ -33,6 +34,11 @@ module Line
             @sender = sender
             @original_content_url = original_content_url
             @duration = duration
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/bot_info_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/bot_info_response.rb
@@ -28,7 +28,8 @@ module Line
             display_name:,
             picture_url: nil,
             chat_mode:,
-            mark_as_read_mode:
+            mark_as_read_mode:,
+            **dynamic_attributes
           )
             
             @user_id = user_id
@@ -38,6 +39,11 @@ module Line
             @picture_url = picture_url
             @chat_mode = chat_mode
             @mark_as_read_mode = mark_as_read_mode
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/broadcast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/broadcast_request.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             messages:,
-            notification_disabled: false
+            notification_disabled: false,
+            **dynamic_attributes
           )
             
             @messages = messages
             @notification_disabled = notification_disabled
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/buttons_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/buttons_template.rb
@@ -32,7 +32,8 @@ module Line
             title: nil,
             text:,
             default_action: nil,
-            actions:
+            actions:,
+            **dynamic_attributes
           )
             @type = "buttons"
             
@@ -44,6 +45,11 @@ module Line
             @text = text
             @default_action = default_action
             @actions = actions
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/camera_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/camera_action.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :label # Label for the action.
 
           def initialize(
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             @type = "camera"
             
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/camera_roll_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/camera_roll_action.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :label # Label for the action.
 
           def initialize(
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             @type = "cameraRoll"
             
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/carousel_column.rb
+++ b/lib/line/bot/v2/messaging_api/model/carousel_column.rb
@@ -26,7 +26,8 @@ module Line
             title: nil,
             text:,
             default_action: nil,
-            actions:
+            actions:,
+            **dynamic_attributes
           )
             
             @thumbnail_image_url = thumbnail_image_url
@@ -35,6 +36,11 @@ module Line
             @text = text
             @default_action = default_action
             @actions = actions
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/carousel_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/carousel_template.rb
@@ -22,13 +22,19 @@ module Line
           def initialize(
             columns:,
             image_aspect_ratio: nil,
-            image_size: nil
+            image_size: nil,
+            **dynamic_attributes
           )
             @type = "carousel"
             
             @columns = columns
             @image_aspect_ratio = image_aspect_ratio
             @image_size = image_size
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/chat_reference.rb
+++ b/lib/line/bot/v2/messaging_api/model/chat_reference.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :user_id # The target user ID
 
           def initialize(
-            user_id:
+            user_id:,
+            **dynamic_attributes
           )
             
             @user_id = user_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/clipboard_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/clipboard_action.rb
@@ -21,12 +21,18 @@ module Line
 
           def initialize(
             label: nil,
-            clipboard_text:
+            clipboard_text:,
+            **dynamic_attributes
           )
             @type = "clipboard"
             
             @label = label
             @clipboard_text = clipboard_text
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rb
@@ -23,13 +23,19 @@ module Line
           def initialize(
             area:,
             clipboard_text:,
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             @type = "clipboard"
             
             @area = area
             @clipboard_text = clipboard_text
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/confirm_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/confirm_template.rb
@@ -20,12 +20,18 @@ module Line
 
           def initialize(
             text:,
-            actions:
+            actions:,
+            **dynamic_attributes
           )
             @type = "confirm"
             
             @text = text
             @actions = actions
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             rich_menu_alias_id:,
-            rich_menu_id:
+            rich_menu_id:,
+            **dynamic_attributes
           )
             
             @rich_menu_alias_id = rich_menu_alias_id
             @rich_menu_id = rich_menu_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/datetime_picker_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/datetime_picker_action.rb
@@ -29,7 +29,8 @@ module Line
             mode: nil,
             initial: nil,
             max: nil,
-            min: nil
+            min: nil,
+            **dynamic_attributes
           )
             @type = "datetimepicker"
             
@@ -39,6 +40,11 @@ module Line
             @initial = initial
             @max = max
             @min = min
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/demographic_filter.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :type # Type of demographic filter
 
           def initialize(
-            type: nil
+            type: nil,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/emoji.rb
+++ b/lib/line/bot/v2/messaging_api/model/emoji.rb
@@ -19,12 +19,18 @@ module Line
           def initialize(
             index: nil,
             product_id: nil,
-            emoji_id: nil
+            emoji_id: nil,
+            **dynamic_attributes
           )
             
             @index = index
             @product_id = product_id
             @emoji_id = emoji_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/emoji_substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/emoji_substitution_object.rb
@@ -22,12 +22,18 @@ module Line
 
           def initialize(
             product_id:,
-            emoji_id:
+            emoji_id:,
+            **dynamic_attributes
           )
             @type = "emoji"
             
             @product_id = product_id
             @emoji_id = emoji_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/error_detail.rb
+++ b/lib/line/bot/v2/messaging_api/model/error_detail.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             message: nil,
-            property: nil
+            property: nil,
+            **dynamic_attributes
           )
             
             @message = message
             @property = property
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/error_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/error_response.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             message:,
             details: nil,
-            sent_messages: nil
+            sent_messages: nil,
+            **dynamic_attributes
           )
             
             @message = message
             @details = details
             @sent_messages = sent_messages
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/filter.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :demographic
 
           def initialize(
-            demographic: nil
+            demographic: nil,
+            **dynamic_attributes
           )
             
             @demographic = demographic
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_block_style.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_block_style.rb
@@ -19,12 +19,18 @@ module Line
           def initialize(
             background_color: nil,
             separator: nil,
-            separator_color: nil
+            separator_color: nil,
+            **dynamic_attributes
           )
             
             @background_color = background_color
             @separator = separator
             @separator_color = separator_color
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box.rb
@@ -70,7 +70,8 @@ module Line
             action: nil,
             justify_content: nil,
             align_items: nil,
-            background: nil
+            background: nil,
+            **dynamic_attributes
           )
             @type = "box"
             
@@ -101,6 +102,11 @@ module Line
             @justify_content = justify_content
             @align_items = align_items
             @background = background
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_background.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_background.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :type
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_border_width.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_border_width.rb
@@ -15,8 +15,14 @@ module Line
         class FlexBoxBorderWidth
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_corner_radius.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_corner_radius.rb
@@ -15,8 +15,14 @@ module Line
         class FlexBoxCornerRadius
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rb
@@ -26,7 +26,8 @@ module Line
             start_color: nil,
             end_color: nil,
             center_color: nil,
-            center_position: nil
+            center_position: nil,
+            **dynamic_attributes
           )
             @type = "linearGradient"
             
@@ -35,6 +36,11 @@ module Line
             @end_color = end_color
             @center_color = center_color
             @center_position = center_position
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_padding.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_padding.rb
@@ -15,8 +15,14 @@ module Line
         class FlexBoxPadding
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_spacing.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_spacing.rb
@@ -15,8 +15,14 @@ module Line
         class FlexBoxSpacing
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_bubble.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_bubble.rb
@@ -32,7 +32,8 @@ module Line
             body: nil,
             footer: nil,
             size: nil,
-            action: nil
+            action: nil,
+            **dynamic_attributes
           )
             @type = "bubble"
             
@@ -44,6 +45,11 @@ module Line
             @footer = footer
             @size = size
             @action = action
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_bubble_styles.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_bubble_styles.rb
@@ -21,13 +21,19 @@ module Line
             header: nil,
             hero: nil,
             body: nil,
-            footer: nil
+            footer: nil,
+            **dynamic_attributes
           )
             
             @header = header
             @hero = hero
             @body = body
             @footer = footer
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_button.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_button.rb
@@ -44,7 +44,8 @@ module Line
             offset_end: nil,
             height: nil,
             adjust_mode: nil,
-            scaling: nil
+            scaling: nil,
+            **dynamic_attributes
           )
             @type = "button"
             
@@ -62,6 +63,11 @@ module Line
             @height = height
             @adjust_mode = adjust_mode
             @scaling = scaling
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_carousel.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_carousel.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :contents
 
           def initialize(
-            contents:
+            contents:,
+            **dynamic_attributes
           )
             @type = "carousel"
             
             @contents = contents
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_component.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_component.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :type
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_container.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_container.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :type
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_filler.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_filler.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :flex
 
           def initialize(
-            flex: nil
+            flex: nil,
+            **dynamic_attributes
           )
             @type = "filler"
             
             @flex = flex
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_icon.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_icon.rb
@@ -37,7 +37,8 @@ module Line
             offset_bottom: nil,
             offset_start: nil,
             offset_end: nil,
-            scaling: nil
+            scaling: nil,
+            **dynamic_attributes
           )
             @type = "icon"
             
@@ -51,6 +52,11 @@ module Line
             @offset_start = offset_start
             @offset_end = offset_end
             @scaling = scaling
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_icon_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_icon_size.rb
@@ -15,8 +15,14 @@ module Line
         class FlexIconSize
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_image.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_image.rb
@@ -49,7 +49,8 @@ module Line
             aspect_mode: nil,
             background_color: nil,
             action: nil,
-            animated: false
+            animated: false,
+            **dynamic_attributes
           )
             @type = "image"
             
@@ -69,6 +70,11 @@ module Line
             @background_color = background_color
             @action = action
             @animated = animated
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_image_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_image_size.rb
@@ -15,8 +15,14 @@ module Line
         class FlexImageSize
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_margin.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_margin.rb
@@ -15,8 +15,14 @@ module Line
         class FlexMargin
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_message.rb
@@ -25,7 +25,8 @@ module Line
             quick_reply: nil,
             sender: nil,
             alt_text:,
-            contents:
+            contents:,
+            **dynamic_attributes
           )
             @type = "flex"
             
@@ -33,6 +34,11 @@ module Line
             @sender = sender
             @alt_text = alt_text
             @contents = contents
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_offset.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_offset.rb
@@ -15,8 +15,14 @@ module Line
         class FlexOffset
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_separator.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_separator.rb
@@ -20,12 +20,18 @@ module Line
 
           def initialize(
             margin: nil,
-            color: nil
+            color: nil,
+            **dynamic_attributes
           )
             @type = "separator"
             
             @margin = margin
             @color = color
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_span.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_span.rb
@@ -28,7 +28,8 @@ module Line
             color: nil,
             weight: nil,
             style: nil,
-            decoration: nil
+            decoration: nil,
+            **dynamic_attributes
           )
             @type = "span"
             
@@ -38,6 +39,11 @@ module Line
             @weight = weight
             @style = style
             @decoration = decoration
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_span_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_span_size.rb
@@ -15,8 +15,14 @@ module Line
         class FlexSpanSize
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_text.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_text.rb
@@ -60,7 +60,8 @@ module Line
             max_lines: nil,
             contents: nil,
             adjust_mode: nil,
-            scaling: nil
+            scaling: nil,
+            **dynamic_attributes
           )
             @type = "text"
             
@@ -86,6 +87,11 @@ module Line
             @contents = contents
             @adjust_mode = adjust_mode
             @scaling = scaling
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_text_font_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_text_font_size.rb
@@ -15,8 +15,14 @@ module Line
         class FlexTextFontSize
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_video.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_video.rb
@@ -26,7 +26,8 @@ module Line
             preview_url:,
             alt_content:,
             aspect_ratio: nil,
-            action: nil
+            action: nil,
+            **dynamic_attributes
           )
             @type = "video"
             
@@ -35,6 +36,11 @@ module Line
             @alt_content = alt_content
             @aspect_ratio = aspect_ratio
             @action = action
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/gender_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/gender_demographic.rb
@@ -14,8 +14,14 @@ module Line
         class GenderDemographic
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :one_of
 
           def initialize(
-            one_of: nil
+            one_of: nil,
+            **dynamic_attributes
           )
             @type = "gender"
             
             @one_of = one_of
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             custom_aggregation_units:,
-            _next: nil
+            _next: nil,
+            **dynamic_attributes
           )
             
             @custom_aggregation_units = custom_aggregation_units
             @_next = _next
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :num_of_custom_aggregation_units # Number of aggregation units used this month.
 
           def initialize(
-            num_of_custom_aggregation_units:
+            num_of_custom_aggregation_units:,
+            **dynamic_attributes
           )
             
             @num_of_custom_aggregation_units = num_of_custom_aggregation_units
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             user_ids:,
-            _next: nil
+            _next: nil,
+            **dynamic_attributes
           )
             
             @user_ids = user_ids
             @_next = _next
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             user_ids:,
-            _next: nil
+            _next: nil,
+            **dynamic_attributes
           )
             
             @user_ids = user_ids
             @_next = _next
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_membership_subscription_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_membership_subscription_response.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :subscriptions # List of subscription information
 
           def initialize(
-            subscriptions:
+            subscriptions:,
+            **dynamic_attributes
           )
             
             @subscriptions = subscriptions
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :status # The preparation status. One of:  `processing`: Preparing to get content. `succeeded`: Ready to get the content. You can get the content sent by users. `failed`: Failed to prepare to get the content. 
 
           def initialize(
-            status:
+            status:,
+            **dynamic_attributes
           )
             
             @status = status
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             endpoint:,
-            active:
+            active:,
+            **dynamic_attributes
           )
             
             @endpoint = endpoint
             @active = active
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/group_member_count_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_member_count_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :count # The count of members in the group chat. The number returned excludes the LINE Official Account.
 
           def initialize(
-            count:
+            count:,
+            **dynamic_attributes
           )
             
             @count = count
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/group_summary_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_summary_response.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             group_id:,
             group_name:,
-            picture_url: nil
+            picture_url: nil,
+            **dynamic_attributes
           )
             
             @group_id = group_id
             @group_name = group_name
             @picture_url = picture_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/group_user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_user_profile_response.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             display_name:,
             user_id:,
-            picture_url: nil
+            picture_url: nil,
+            **dynamic_attributes
           )
             
             @display_name = display_name
             @user_id = user_id
             @picture_url = picture_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/image_carousel_column.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_carousel_column.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             image_url:,
-            action:
+            action:,
+            **dynamic_attributes
           )
             
             @image_url = image_url
             @action = action
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/image_carousel_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_carousel_template.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :columns
 
           def initialize(
-            columns:
+            columns:,
+            **dynamic_attributes
           )
             @type = "image_carousel"
             
             @columns = columns
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/image_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_message.rb
@@ -25,7 +25,8 @@ module Line
             quick_reply: nil,
             sender: nil,
             original_content_url:,
-            preview_image_url:
+            preview_image_url:,
+            **dynamic_attributes
           )
             @type = "image"
             
@@ -33,6 +34,11 @@ module Line
             @sender = sender
             @original_content_url = original_content_url
             @preview_image_url = preview_image_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_action.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             type:,
-            area:
+            area:,
+            **dynamic_attributes
           )
             
             @type = type
             @area = area
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_area.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_area.rb
@@ -21,13 +21,19 @@ module Line
             x:,
             y:,
             width:,
-            height:
+            height:,
+            **dynamic_attributes
           )
             
             @x = x
             @y = y
             @width = width
             @height = height
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_base_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_base_size.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             height:,
-            width:
+            width:,
+            **dynamic_attributes
           )
             
             @height = height
             @width = width
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_external_link.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_external_link.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             link_uri: nil,
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             
             @link_uri = link_uri
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_message.rb
@@ -31,7 +31,8 @@ module Line
             alt_text:,
             base_size:,
             actions:,
-            video: nil
+            video: nil,
+            **dynamic_attributes
           )
             @type = "imagemap"
             
@@ -42,6 +43,11 @@ module Line
             @base_size = base_size
             @actions = actions
             @video = video
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_video.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_video.rb
@@ -21,13 +21,19 @@ module Line
             original_content_url: nil,
             preview_image_url: nil,
             area: nil,
-            external_link: nil
+            external_link: nil,
+            **dynamic_attributes
           )
             
             @original_content_url = original_content_url
             @preview_image_url = preview_image_url
             @area = area
             @external_link = external_link
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/issue_link_token_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/issue_link_token_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :link_token # Link token. Link tokens are valid for 10 minutes and can only be used once.  
 
           def initialize(
-            link_token:
+            link_token:,
+            **dynamic_attributes
           )
             
             @link_token = link_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/limit.rb
+++ b/lib/line/bot/v2/messaging_api/model/limit.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             max: nil,
-            up_to_remaining_quota: false
+            up_to_remaining_quota: false,
+            **dynamic_attributes
           )
             
             @max = max
             @up_to_remaining_quota = up_to_remaining_quota
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/location_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/location_action.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :label # Label for the action.
 
           def initialize(
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             @type = "location"
             
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/location_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/location_message.rb
@@ -29,7 +29,8 @@ module Line
             title:,
             address:,
             latitude:,
-            longitude:
+            longitude:,
+            **dynamic_attributes
           )
             @type = "location"
             
@@ -39,6 +40,11 @@ module Line
             @address = address
             @latitude = latitude
             @longitude = longitude
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :chat
 
           def initialize(
-            chat:
+            chat:,
+            **dynamic_attributes
           )
             
             @chat = chat
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             member_ids:,
-            _next: nil
+            _next: nil,
+            **dynamic_attributes
           )
             
             @member_ids = member_ids
             @_next = _next
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/membership.rb
+++ b/lib/line/bot/v2/messaging_api/model/membership.rb
@@ -33,7 +33,8 @@ module Line
             member_count:,
             member_limit:,
             is_in_app_purchase:,
-            is_published:
+            is_published:,
+            **dynamic_attributes
           )
             
             @membership_id = membership_id
@@ -46,6 +47,11 @@ module Line
             @member_limit = member_limit
             @is_in_app_purchase = is_in_app_purchase
             @is_published = is_published
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/membership_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/membership_list_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :memberships # List of membership information
 
           def initialize(
-            memberships:
+            memberships:,
+            **dynamic_attributes
           )
             
             @memberships = memberships
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/mention_substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/mention_substitution_object.rb
@@ -20,11 +20,17 @@ module Line
           attr_accessor :mentionee
 
           def initialize(
-            mentionee:
+            mentionee:,
+            **dynamic_attributes
           )
             @type = "mention"
             
             @mentionee = mentionee
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/mention_target.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :type # Target to be mentioned
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/message.rb
+++ b/lib/line/bot/v2/messaging_api/model/message.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             type:,
             quick_reply: nil,
-            sender: nil
+            sender: nil,
+            **dynamic_attributes
           )
             
             @type = type
             @quick_reply = quick_reply
             @sender = sender
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/message_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_action.rb
@@ -20,12 +20,18 @@ module Line
 
           def initialize(
             label: nil,
-            text: nil
+            text: nil,
+            **dynamic_attributes
           )
             @type = "message"
             
             @label = label
             @text = text
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/message_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_imagemap_action.rb
@@ -22,13 +22,19 @@ module Line
           def initialize(
             area:,
             text:,
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             @type = "message"
             
             @area = area
             @text = text
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/message_quota_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_quota_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             type:,
-            value: nil
+            value: nil,
+            **dynamic_attributes
           )
             
             @type = type
             @value = value
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/multicast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/multicast_request.rb
@@ -22,13 +22,19 @@ module Line
             messages:,
             to:,
             notification_disabled: false,
-            custom_aggregation_units: nil
+            custom_aggregation_units: nil,
+            **dynamic_attributes
           )
             
             @messages = messages
             @to = to
             @notification_disabled = notification_disabled
             @custom_aggregation_units = custom_aggregation_units
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/narrowcast_progress_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/narrowcast_progress_response.rb
@@ -30,7 +30,8 @@ module Line
             failed_description: nil,
             error_code: nil,
             accepted_time:,
-            completed_time: nil
+            completed_time: nil,
+            **dynamic_attributes
           )
             
             @phase = phase
@@ -41,6 +42,11 @@ module Line
             @error_code = error_code
             @accepted_time = accepted_time
             @completed_time = completed_time
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/narrowcast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/narrowcast_request.rb
@@ -24,7 +24,8 @@ module Line
             recipient: nil,
             filter: nil,
             limit: nil,
-            notification_disabled: false
+            notification_disabled: false,
+            **dynamic_attributes
           )
             
             @messages = messages
@@ -32,6 +33,11 @@ module Line
             @filter = filter
             @limit = limit
             @notification_disabled = notification_disabled
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/number_of_messages_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/number_of_messages_response.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             status:,
-            success: nil
+            success: nil,
+            **dynamic_attributes
           )
             
             @status = status
             @success = success
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/operator_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/operator_demographic_filter.rb
@@ -22,13 +22,19 @@ module Line
           def initialize(
             _and: nil,
             _or: nil,
-            _not: nil
+            _not: nil,
+            **dynamic_attributes
           )
             @type = "operator"
             
             @_and = _and
             @_or = _or
             @_not = _not
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/operator_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/operator_recipient.rb
@@ -22,13 +22,19 @@ module Line
           def initialize(
             _and: nil,
             _or: nil,
-            _not: nil
+            _not: nil,
+            **dynamic_attributes
           )
             @type = "operator"
             
             @_and = _and
             @_or = _or
             @_not = _not
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/pnp_messages_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/pnp_messages_request.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             messages:,
             to:,
-            notification_disabled: false
+            notification_disabled: false,
+            **dynamic_attributes
           )
             
             @messages = messages
             @to = to
             @notification_disabled = notification_disabled
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/postback_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/postback_action.rb
@@ -28,7 +28,8 @@ module Line
             display_text: nil,
             text: nil,
             input_option: nil,
-            fill_in_text: nil
+            fill_in_text: nil,
+            **dynamic_attributes
           )
             @type = "postback"
             
@@ -38,6 +39,11 @@ module Line
             @text = text
             @input_option = input_option
             @fill_in_text = fill_in_text
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/push_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/push_message_request.rb
@@ -22,13 +22,19 @@ module Line
             to:,
             messages:,
             notification_disabled: false,
-            custom_aggregation_units: nil
+            custom_aggregation_units: nil,
+            **dynamic_attributes
           )
             
             @to = to
             @messages = messages
             @notification_disabled = notification_disabled
             @custom_aggregation_units = custom_aggregation_units
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/push_message_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/push_message_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :sent_messages # Array of sent messages.
 
           def initialize(
-            sent_messages:
+            sent_messages:,
+            **dynamic_attributes
           )
             
             @sent_messages = sent_messages
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quick_reply.rb
+++ b/lib/line/bot/v2/messaging_api/model/quick_reply.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :items # Quick reply button objects.
 
           def initialize(
-            items: nil
+            items: nil,
+            **dynamic_attributes
           )
             
             @items = items
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quick_reply_item.rb
+++ b/lib/line/bot/v2/messaging_api/model/quick_reply_item.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             image_url: nil,
             action: nil,
-            type: 'action'
+            type: 'action',
+            **dynamic_attributes
           )
             
             @image_url = image_url
             @action = action
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quota_consumption_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/quota_consumption_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :total_usage # The number of sent messages in the current month
 
           def initialize(
-            total_usage:
+            total_usage:,
+            **dynamic_attributes
           )
             
             @total_usage = total_usage
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quota_type.rb
+++ b/lib/line/bot/v2/messaging_api/model/quota_type.rb
@@ -16,8 +16,14 @@ module Line
         class QuotaType
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/recipient.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :type # Type of recipient
 
           def initialize(
-            type: nil
+            type: nil,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/redelivery_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/redelivery_recipient.rb
@@ -18,11 +18,17 @@ module Line
           attr_accessor :request_id
 
           def initialize(
-            request_id: nil
+            request_id: nil,
+            **dynamic_attributes
           )
             @type = "redelivery"
             
             @request_id = request_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/reply_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/reply_message_request.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             reply_token:,
             messages:,
-            notification_disabled: false
+            notification_disabled: false,
+            **dynamic_attributes
           )
             
             @reply_token = reply_token
             @messages = messages
             @notification_disabled = notification_disabled
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/reply_message_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/reply_message_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :sent_messages # Array of sent messages.
 
           def initialize(
-            sent_messages:
+            sent_messages:,
+            **dynamic_attributes
           )
             
             @sent_messages = sent_messages
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :aliases # Rich menu aliases.
 
           def initialize(
-            aliases:
+            aliases:,
+            **dynamic_attributes
           )
             
             @aliases = aliases
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_alias_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_alias_response.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             rich_menu_alias_id:,
-            rich_menu_id:
+            rich_menu_id:,
+            **dynamic_attributes
           )
             
             @rich_menu_alias_id = rich_menu_alias_id
             @rich_menu_id = rich_menu_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_area.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_area.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             bounds: nil,
-            action: nil
+            action: nil,
+            **dynamic_attributes
           )
             
             @bounds = bounds
             @action = action
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rb
@@ -21,12 +21,18 @@ module Line
 
           def initialize(
             from:,
-            to:
+            to:,
+            **dynamic_attributes
           )
             @type = "link"
             
             @from = from
             @to = to
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :type # The type of operation to the rich menu linked to the user. One of link, unlink, or unlinkAll.
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_phase.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_phase.rb
@@ -15,8 +15,14 @@ module Line
         class RichMenuBatchProgressPhase
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             phase:,
             accepted_time:,
-            completed_time: nil
+            completed_time: nil,
+            **dynamic_attributes
           )
             
             @phase = phase
             @accepted_time = accepted_time
             @completed_time = completed_time
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_request.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             operations:,
-            resume_request_key: nil
+            resume_request_key: nil,
+            **dynamic_attributes
           )
             
             @operations = operations
             @resume_request_key = resume_request_key
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rb
@@ -18,9 +18,15 @@ module Line
           attr_reader :type # The type of operation to the rich menu linked to the user. One of link, unlink, or unlinkAll.
 
           def initialize(
+            **dynamic_attributes
           )
             @type = "unlinkAll"
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rb
@@ -19,11 +19,17 @@ module Line
           attr_accessor :from
 
           def initialize(
-            from:
+            from:,
+            **dynamic_attributes
           )
             @type = "unlink"
             
             @from = from
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bounds.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bounds.rb
@@ -23,13 +23,19 @@ module Line
             x: nil,
             y: nil,
             width: nil,
-            height: nil
+            height: nil,
+            **dynamic_attributes
           )
             
             @x = x
             @y = y
             @width = width
             @height = height
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             rich_menu_id:,
-            user_ids:
+            user_ids:,
+            **dynamic_attributes
           )
             
             @rich_menu_id = rich_menu_id
             @user_ids = user_ids
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :user_ids # Array of user IDs. Found in the `source` object of webhook event objects. Do not use the LINE ID used in LINE.
 
           def initialize(
-            user_ids:
+            user_ids:,
+            **dynamic_attributes
           )
             
             @user_ids = user_ids
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_id_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_id_response.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :rich_menu_id # Rich menu ID
 
           def initialize(
-            rich_menu_id:
+            rich_menu_id:,
+            **dynamic_attributes
           )
             
             @rich_menu_id = rich_menu_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_list_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :richmenus # Rich menus
 
           def initialize(
-            richmenus:
+            richmenus:,
+            **dynamic_attributes
           )
             
             @richmenus = richmenus
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_request.rb
@@ -23,7 +23,8 @@ module Line
             selected: nil,
             name: nil,
             chat_bar_text: nil,
-            areas: nil
+            areas: nil,
+            **dynamic_attributes
           )
             
             @size = size
@@ -31,6 +32,11 @@ module Line
             @name = name
             @chat_bar_text = chat_bar_text
             @areas = areas
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_response.rb
@@ -25,7 +25,8 @@ module Line
             selected:,
             name:,
             chat_bar_text:,
-            areas:
+            areas:,
+            **dynamic_attributes
           )
             
             @rich_menu_id = rich_menu_id
@@ -34,6 +35,11 @@ module Line
             @name = name
             @chat_bar_text = chat_bar_text
             @areas = areas
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_size.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             width: nil,
-            height: nil
+            height: nil,
+            **dynamic_attributes
           )
             
             @width = width
             @height = height
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_switch_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_switch_action.rb
@@ -22,13 +22,19 @@ module Line
           def initialize(
             label: nil,
             data: nil,
-            rich_menu_alias_id: nil
+            rich_menu_alias_id: nil,
+            **dynamic_attributes
           )
             @type = "richmenuswitch"
             
             @label = label
             @data = data
             @rich_menu_alias_id = rich_menu_alias_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/room_member_count_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/room_member_count_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :count # The count of members in the multi-person chat. The number returned excludes the LINE Official Account.
 
           def initialize(
-            count:
+            count:,
+            **dynamic_attributes
           )
             
             @count = count
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/room_user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/room_user_profile_response.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             display_name:,
             user_id:,
-            picture_url: nil
+            picture_url: nil,
+            **dynamic_attributes
           )
             
             @display_name = display_name
             @user_id = user_id
             @picture_url = picture_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/sender.rb
+++ b/lib/line/bot/v2/messaging_api/model/sender.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             name: nil,
-            icon_url: nil
+            icon_url: nil,
+            **dynamic_attributes
           )
             
             @name = name
             @icon_url = icon_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/sent_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/sent_message.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             id:,
-            quote_token: nil
+            quote_token: nil,
+            **dynamic_attributes
           )
             
             @id = id
             @quote_token = quote_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :endpoint # A valid webhook URL.
 
           def initialize(
-            endpoint:
+            endpoint:,
+            **dynamic_attributes
           )
             
             @endpoint = endpoint
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/show_loading_animation_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/show_loading_animation_request.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             chat_id:,
-            loading_seconds: nil
+            loading_seconds: nil,
+            **dynamic_attributes
           )
             
             @chat_id = chat_id
             @loading_seconds = loading_seconds
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/sticker_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/sticker_message.rb
@@ -27,7 +27,8 @@ module Line
             sender: nil,
             package_id:,
             sticker_id:,
-            quote_token: nil
+            quote_token: nil,
+            **dynamic_attributes
           )
             @type = "sticker"
             
@@ -36,6 +37,11 @@ module Line
             @package_id = package_id
             @sticker_id = sticker_id
             @quote_token = quote_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
@@ -26,7 +26,8 @@ module Line
             description:,
             benefits:,
             price:,
-            currency:
+            currency:,
+            **dynamic_attributes
           )
             
             @membership_id = membership_id
@@ -35,6 +36,11 @@ module Line
             @benefits = benefits
             @price = price
             @currency = currency
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscribed_membership_user.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscribed_membership_user.rb
@@ -22,13 +22,19 @@ module Line
             membership_no:,
             joined_time:,
             next_billing_date:,
-            total_subscription_months:
+            total_subscription_months:,
+            **dynamic_attributes
           )
             
             @membership_no = membership_no
             @joined_time = joined_time
             @next_billing_date = next_billing_date
             @total_subscription_months = total_subscription_months
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscription.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             membership:,
-            user:
+            user:,
+            **dynamic_attributes
           )
             
             @membership = membership
             @user = user
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscription_period_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription_period_demographic.rb
@@ -14,8 +14,14 @@ module Line
         class SubscriptionPeriodDemographic
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rb
@@ -20,12 +20,18 @@ module Line
 
           def initialize(
             gte: nil,
-            lt: nil
+            lt: nil,
+            **dynamic_attributes
           )
             @type = "subscriptionPeriod"
             
             @gte = gte
             @lt = lt
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/substitution_object.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :type # Type of substitution object
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template.rb
+++ b/lib/line/bot/v2/messaging_api/model/template.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :type
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template_image_aspect_ratio.rb
+++ b/lib/line/bot/v2/messaging_api/model/template_image_aspect_ratio.rb
@@ -15,8 +15,14 @@ module Line
         class TemplateImageAspectRatio
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template_image_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/template_image_size.rb
@@ -15,8 +15,14 @@ module Line
         class TemplateImageSize
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/template_message.rb
@@ -25,7 +25,8 @@ module Line
             quick_reply: nil,
             sender: nil,
             alt_text:,
-            template:
+            template:,
+            **dynamic_attributes
           )
             @type = "template"
             
@@ -33,6 +34,11 @@ module Line
             @sender = sender
             @alt_text = alt_text
             @template = template
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :endpoint # A webhook URL to be validated.
 
           def initialize(
-            endpoint: nil
+            endpoint: nil,
+            **dynamic_attributes
           )
             
             @endpoint = endpoint
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rb
@@ -24,7 +24,8 @@ module Line
             timestamp:,
             status_code:,
             reason:,
-            detail:
+            detail:,
+            **dynamic_attributes
           )
             
             @success = success
@@ -32,6 +33,11 @@ module Line
             @status_code = status_code
             @reason = reason
             @detail = detail
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/text_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/text_message.rb
@@ -27,7 +27,8 @@ module Line
             sender: nil,
             text:,
             emojis: nil,
-            quote_token: nil
+            quote_token: nil,
+            **dynamic_attributes
           )
             @type = "text"
             
@@ -36,6 +37,11 @@ module Line
             @text = text
             @emojis = emojis
             @quote_token = quote_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/text_message_v2.rb
+++ b/lib/line/bot/v2/messaging_api/model/text_message_v2.rb
@@ -27,7 +27,8 @@ module Line
             sender: nil,
             text:,
             substitution: nil,
-            quote_token: nil
+            quote_token: nil,
+            **dynamic_attributes
           )
             @type = "textV2"
             
@@ -36,6 +37,11 @@ module Line
             @text = text
             @substitution = substitution
             @quote_token = quote_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :rich_menu_id # The rich menu ID to be associated with the rich menu alias.
 
           def initialize(
-            rich_menu_id:
+            rich_menu_id:,
+            **dynamic_attributes
           )
             
             @rich_menu_id = rich_menu_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/uri_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/uri_action.rb
@@ -22,13 +22,19 @@ module Line
           def initialize(
             label: nil,
             uri: nil,
-            alt_uri: nil
+            alt_uri: nil,
+            **dynamic_attributes
           )
             @type = "uri"
             
             @label = label
             @uri = uri
             @alt_uri = alt_uri
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/uri_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/uri_imagemap_action.rb
@@ -22,13 +22,19 @@ module Line
           def initialize(
             area:,
             link_uri:,
-            label: nil
+            label: nil,
+            **dynamic_attributes
           )
             @type = "uri"
             
             @area = area
             @link_uri = link_uri
             @label = label
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/user_mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/user_mention_target.rb
@@ -19,11 +19,17 @@ module Line
           attr_accessor :user_id
 
           def initialize(
-            user_id:
+            user_id:,
+            **dynamic_attributes
           )
             @type = "user"
             
             @user_id = user_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/user_profile_response.rb
@@ -24,7 +24,8 @@ module Line
             user_id:,
             picture_url: nil,
             status_message: nil,
-            language: nil
+            language: nil,
+            **dynamic_attributes
           )
             
             @display_name = display_name
@@ -32,6 +33,11 @@ module Line
             @picture_url = picture_url
             @status_message = status_message
             @language = language
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/validate_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/validate_message_request.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :messages # Array of message objects to validate
 
           def initialize(
-            messages:
+            messages:,
+            **dynamic_attributes
           )
             
             @messages = messages
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/video_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/video_message.rb
@@ -27,7 +27,8 @@ module Line
             sender: nil,
             original_content_url:,
             preview_image_url:,
-            tracking_id: nil
+            tracking_id: nil,
+            **dynamic_attributes
           )
             @type = "video"
             
@@ -36,6 +37,11 @@ module Line
             @original_content_url = original_content_url
             @preview_image_url = preview_image_url
             @tracking_id = tracking_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/module/model/acquire_chat_control_request.rb
+++ b/lib/line/bot/v2/module/model/acquire_chat_control_request.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             expired: nil,
-            ttl: nil
+            ttl: nil,
+            **dynamic_attributes
           )
             
             @expired = expired
             @ttl = ttl
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/module/model/detach_module_request.rb
+++ b/lib/line/bot/v2/module/model/detach_module_request.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :bot_id # User ID of the LINE Official Account bot attached to the module channel.
 
           def initialize(
-            bot_id: nil
+            bot_id: nil,
+            **dynamic_attributes
           )
             
             @bot_id = bot_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/module/model/get_modules_response.rb
+++ b/lib/line/bot/v2/module/model/get_modules_response.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             bots:,
-            _next: nil
+            _next: nil,
+            **dynamic_attributes
           )
             
             @bots = bots
             @_next = _next
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/module/model/module_bot.rb
+++ b/lib/line/bot/v2/module/model/module_bot.rb
@@ -25,7 +25,8 @@ module Line
             basic_id:,
             premium_id: nil,
             display_name:,
-            picture_url: nil
+            picture_url: nil,
+            **dynamic_attributes
           )
             
             @user_id = user_id
@@ -33,6 +34,11 @@ module Line
             @premium_id = premium_id
             @display_name = display_name
             @picture_url = picture_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/module_attach/model/attach_module_response.rb
+++ b/lib/line/bot/v2/module_attach/model/attach_module_response.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             bot_id:,
-            scopes:
+            scopes:,
+            **dynamic_attributes
           )
             
             @bot_id = bot_id
             @scopes = scopes
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/shop/model/error_response.rb
+++ b/lib/line/bot/v2/shop/model/error_response.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :message # Message containing information about the error.
 
           def initialize(
-            message:
+            message:,
+            **dynamic_attributes
           )
             
             @message = message
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/shop/model/mission_sticker_request.rb
+++ b/lib/line/bot/v2/shop/model/mission_sticker_request.rb
@@ -23,13 +23,19 @@ module Line
             to:,
             product_id:,
             product_type:,
-            send_present_message:
+            send_present_message:,
+            **dynamic_attributes
           )
             
             @to = to
             @product_id = product_id
             @product_type = product_type
             @send_present_message = send_present_message
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/account_link_event.rb
+++ b/lib/line/bot/v2/webhook/model/account_link_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token: nil,
-            link:
+            link:,
+            **dynamic_attributes
           )
             @type = "accountLink"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @link = link
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/action_result.rb
+++ b/lib/line/bot/v2/webhook/model/action_result.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             type:,
-            data: nil
+            data: nil,
+            **dynamic_attributes
           )
             
             @type = type
             @data = data
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/activated_event.rb
+++ b/lib/line/bot/v2/webhook/model/activated_event.rb
@@ -30,7 +30,8 @@ module Line
             mode:,
             webhook_event_id:,
             delivery_context:,
-            chat_control:
+            chat_control:,
+            **dynamic_attributes
           )
             @type = "activated"
             
@@ -40,6 +41,11 @@ module Line
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
             @chat_control = chat_control
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/all_mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/all_mentionee.rb
@@ -22,12 +22,18 @@ module Line
           def initialize(
             type:,
             index:,
-            length:
+            length:,
+            **dynamic_attributes
           )
             @type = "all"
             
             @index = index
             @length = length
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/attached_module_content.rb
+++ b/lib/line/bot/v2/webhook/model/attached_module_content.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             type:,
             bot_id:,
-            scopes:
+            scopes:,
+            **dynamic_attributes
           )
             @type = "attached"
             
             @bot_id = bot_id
             @scopes = scopes
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/audio_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/audio_message_content.rb
@@ -23,13 +23,19 @@ module Line
             type:,
             id:,
             content_provider:,
-            duration: nil
+            duration: nil,
+            **dynamic_attributes
           )
             @type = "audio"
             
             @id = id
             @content_provider = content_provider
             @duration = duration
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/beacon_content.rb
+++ b/lib/line/bot/v2/webhook/model/beacon_content.rb
@@ -19,12 +19,18 @@ module Line
           def initialize(
             hwid:,
             type:,
-            dm: nil
+            dm: nil,
+            **dynamic_attributes
           )
             
             @hwid = hwid
             @type = type
             @dm = dm
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/beacon_event.rb
+++ b/lib/line/bot/v2/webhook/model/beacon_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token:,
-            beacon:
+            beacon:,
+            **dynamic_attributes
           )
             @type = "beacon"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @beacon = beacon
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/bot_resumed_event.rb
+++ b/lib/line/bot/v2/webhook/model/bot_resumed_event.rb
@@ -28,7 +28,8 @@ module Line
             timestamp:,
             mode:,
             webhook_event_id:,
-            delivery_context:
+            delivery_context:,
+            **dynamic_attributes
           )
             @type = "botResumed"
             
@@ -37,6 +38,11 @@ module Line
             @mode = mode
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/bot_suspended_event.rb
+++ b/lib/line/bot/v2/webhook/model/bot_suspended_event.rb
@@ -28,7 +28,8 @@ module Line
             timestamp:,
             mode:,
             webhook_event_id:,
-            delivery_context:
+            delivery_context:,
+            **dynamic_attributes
           )
             @type = "botSuspended"
             
@@ -37,6 +38,11 @@ module Line
             @mode = mode
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/callback_request.rb
+++ b/lib/line/bot/v2/webhook/model/callback_request.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             destination:,
-            events:
+            events:,
+            **dynamic_attributes
           )
             
             @destination = destination
             @events = events
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/chat_control.rb
+++ b/lib/line/bot/v2/webhook/model/chat_control.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :expire_at
 
           def initialize(
-            expire_at:
+            expire_at:,
+            **dynamic_attributes
           )
             
             @expire_at = expire_at
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/content_provider.rb
+++ b/lib/line/bot/v2/webhook/model/content_provider.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             type:,
             original_content_url: nil,
-            preview_image_url: nil
+            preview_image_url: nil,
+            **dynamic_attributes
           )
             
             @type = type
             @original_content_url = original_content_url
             @preview_image_url = preview_image_url
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/deactivated_event.rb
+++ b/lib/line/bot/v2/webhook/model/deactivated_event.rb
@@ -28,7 +28,8 @@ module Line
             timestamp:,
             mode:,
             webhook_event_id:,
-            delivery_context:
+            delivery_context:,
+            **dynamic_attributes
           )
             @type = "deactivated"
             
@@ -37,6 +38,11 @@ module Line
             @mode = mode
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/delivery_context.rb
+++ b/lib/line/bot/v2/webhook/model/delivery_context.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :is_redelivery # Whether the webhook event is a redelivered one or not.
 
           def initialize(
-            is_redelivery:
+            is_redelivery:,
+            **dynamic_attributes
           )
             
             @is_redelivery = is_redelivery
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/detached_module_content.rb
+++ b/lib/line/bot/v2/webhook/model/detached_module_content.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             type:,
             bot_id:,
-            reason:
+            reason:,
+            **dynamic_attributes
           )
             @type = "detached"
             
             @bot_id = bot_id
             @reason = reason
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/emoji.rb
+++ b/lib/line/bot/v2/webhook/model/emoji.rb
@@ -21,13 +21,19 @@ module Line
             index:,
             length:,
             product_id:,
-            emoji_id:
+            emoji_id:,
+            **dynamic_attributes
           )
             
             @index = index
             @length = length
             @product_id = product_id
             @emoji_id = emoji_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/event.rb
+++ b/lib/line/bot/v2/webhook/model/event.rb
@@ -26,7 +26,8 @@ module Line
             timestamp:,
             mode:,
             webhook_event_id:,
-            delivery_context:
+            delivery_context:,
+            **dynamic_attributes
           )
             
             @type = type
@@ -35,6 +36,11 @@ module Line
             @mode = mode
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/event_mode.rb
+++ b/lib/line/bot/v2/webhook/model/event_mode.rb
@@ -15,8 +15,14 @@ module Line
         class EventMode
 
           def initialize(
+            **dynamic_attributes
           )
             
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/file_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/file_message_content.rb
@@ -23,13 +23,19 @@ module Line
             type:,
             id:,
             file_name:,
-            file_size:
+            file_size:,
+            **dynamic_attributes
           )
             @type = "file"
             
             @id = id
             @file_name = file_name
             @file_size = file_size
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/follow_detail.rb
+++ b/lib/line/bot/v2/webhook/model/follow_detail.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :is_unblocked # Whether a user has added your LINE Official Account as a friend or unblocked.
 
           def initialize(
-            is_unblocked:
+            is_unblocked:,
+            **dynamic_attributes
           )
             
             @is_unblocked = is_unblocked
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/follow_event.rb
+++ b/lib/line/bot/v2/webhook/model/follow_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token:,
-            follow:
+            follow:,
+            **dynamic_attributes
           )
             @type = "follow"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @follow = follow
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/group_source.rb
+++ b/lib/line/bot/v2/webhook/model/group_source.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             type:,
             group_id:,
-            user_id: nil
+            user_id: nil,
+            **dynamic_attributes
           )
             @type = "group"
             
             @group_id = group_id
             @user_id = user_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/image_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/image_message_content.rb
@@ -25,7 +25,8 @@ module Line
             id:,
             content_provider:,
             image_set: nil,
-            quote_token:
+            quote_token:,
+            **dynamic_attributes
           )
             @type = "image"
             
@@ -33,6 +34,11 @@ module Line
             @content_provider = content_provider
             @image_set = image_set
             @quote_token = quote_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/image_set.rb
+++ b/lib/line/bot/v2/webhook/model/image_set.rb
@@ -19,12 +19,18 @@ module Line
           def initialize(
             id:,
             index: nil,
-            total: nil
+            total: nil,
+            **dynamic_attributes
           )
             
             @id = id
             @index = index
             @total = total
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/join_event.rb
+++ b/lib/line/bot/v2/webhook/model/join_event.rb
@@ -30,7 +30,8 @@ module Line
             mode:,
             webhook_event_id:,
             delivery_context:,
-            reply_token:
+            reply_token:,
+            **dynamic_attributes
           )
             @type = "join"
             
@@ -40,6 +41,11 @@ module Line
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
             @reply_token = reply_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/joined_members.rb
+++ b/lib/line/bot/v2/webhook/model/joined_members.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :members # Users who joined. Array of source user objects.
 
           def initialize(
-            members:
+            members:,
+            **dynamic_attributes
           )
             
             @members = members
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/joined_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/joined_membership_content.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             type:,
-            membership_id:
+            membership_id:,
+            **dynamic_attributes
           )
             @type = "joined"
             
             @membership_id = membership_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/leave_event.rb
+++ b/lib/line/bot/v2/webhook/model/leave_event.rb
@@ -28,7 +28,8 @@ module Line
             timestamp:,
             mode:,
             webhook_event_id:,
-            delivery_context:
+            delivery_context:,
+            **dynamic_attributes
           )
             @type = "leave"
             
@@ -37,6 +38,11 @@ module Line
             @mode = mode
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/left_members.rb
+++ b/lib/line/bot/v2/webhook/model/left_members.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :members # Users who left. Array of source user objects.
 
           def initialize(
-            members:
+            members:,
+            **dynamic_attributes
           )
             
             @members = members
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/left_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/left_membership_content.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             type:,
-            membership_id:
+            membership_id:,
+            **dynamic_attributes
           )
             @type = "left"
             
             @membership_id = membership_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/link_content.rb
+++ b/lib/line/bot/v2/webhook/model/link_content.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             result:,
-            nonce:
+            nonce:,
+            **dynamic_attributes
           )
             
             @result = result
             @nonce = nonce
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/link_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/link_things_content.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             type:,
-            device_id:
+            device_id:,
+            **dynamic_attributes
           )
             @type = "link"
             
             @device_id = device_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/location_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/location_message_content.rb
@@ -27,7 +27,8 @@ module Line
             title: nil,
             address: nil,
             latitude:,
-            longitude:
+            longitude:,
+            **dynamic_attributes
           )
             @type = "location"
             
@@ -36,6 +37,11 @@ module Line
             @address = address
             @latitude = latitude
             @longitude = longitude
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/member_joined_event.rb
+++ b/lib/line/bot/v2/webhook/model/member_joined_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token:,
-            joined:
+            joined:,
+            **dynamic_attributes
           )
             @type = "memberJoined"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @joined = joined
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/member_left_event.rb
+++ b/lib/line/bot/v2/webhook/model/member_left_event.rb
@@ -30,7 +30,8 @@ module Line
             mode:,
             webhook_event_id:,
             delivery_context:,
-            left:
+            left:,
+            **dynamic_attributes
           )
             @type = "memberLeft"
             
@@ -40,6 +41,11 @@ module Line
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
             @left = left
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/membership_content.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :type # Type of membership event.
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/membership_event.rb
+++ b/lib/line/bot/v2/webhook/model/membership_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token:,
-            membership:
+            membership:,
+            **dynamic_attributes
           )
             @type = "membership"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @membership = membership
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/mention.rb
+++ b/lib/line/bot/v2/webhook/model/mention.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :mentionees # Array of one or more mention objects. Max: 20 mentions
 
           def initialize(
-            mentionees:
+            mentionees:,
+            **dynamic_attributes
           )
             
             @mentionees = mentionees
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/mentionee.rb
@@ -20,12 +20,18 @@ module Line
           def initialize(
             type:,
             index:,
-            length:
+            length:,
+            **dynamic_attributes
           )
             
             @type = type
             @index = index
             @length = length
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/message_content.rb
+++ b/lib/line/bot/v2/webhook/model/message_content.rb
@@ -18,11 +18,17 @@ module Line
 
           def initialize(
             type:,
-            id:
+            id:,
+            **dynamic_attributes
           )
             
             @type = type
             @id = id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/message_event.rb
+++ b/lib/line/bot/v2/webhook/model/message_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token: nil,
-            message:
+            message:,
+            **dynamic_attributes
           )
             @type = "message"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @message = message
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/module_content.rb
+++ b/lib/line/bot/v2/webhook/model/module_content.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :type # Type
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/module_event.rb
+++ b/lib/line/bot/v2/webhook/model/module_event.rb
@@ -30,7 +30,8 @@ module Line
             mode:,
             webhook_event_id:,
             delivery_context:,
-            _module:
+            _module:,
+            **dynamic_attributes
           )
             @type = "module"
             
@@ -40,6 +41,11 @@ module Line
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
             @_module = _module
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/pnp_delivery.rb
+++ b/lib/line/bot/v2/webhook/model/pnp_delivery.rb
@@ -16,10 +16,16 @@ module Line
           attr_accessor :data # A hashed phone number string or a string specified by `X-Line-Delivery-Tag` header
 
           def initialize(
-            data:
+            data:,
+            **dynamic_attributes
           )
             
             @data = data
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/pnp_delivery_completion_event.rb
+++ b/lib/line/bot/v2/webhook/model/pnp_delivery_completion_event.rb
@@ -30,7 +30,8 @@ module Line
             mode:,
             webhook_event_id:,
             delivery_context:,
-            delivery:
+            delivery:,
+            **dynamic_attributes
           )
             @type = "delivery"
             
@@ -40,6 +41,11 @@ module Line
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
             @delivery = delivery
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/postback_content.rb
+++ b/lib/line/bot/v2/webhook/model/postback_content.rb
@@ -17,11 +17,17 @@ module Line
 
           def initialize(
             data:,
-            params: nil
+            params: nil,
+            **dynamic_attributes
           )
             
             @data = data
             @params = params
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/postback_event.rb
+++ b/lib/line/bot/v2/webhook/model/postback_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token: nil,
-            postback:
+            postback:,
+            **dynamic_attributes
           )
             @type = "postback"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @postback = postback
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/renewed_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/renewed_membership_content.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             type:,
-            membership_id:
+            membership_id:,
+            **dynamic_attributes
           )
             @type = "renewed"
             
             @membership_id = membership_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/room_source.rb
+++ b/lib/line/bot/v2/webhook/model/room_source.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             type:,
             user_id: nil,
-            room_id:
+            room_id:,
+            **dynamic_attributes
           )
             @type = "room"
             
             @user_id = user_id
             @room_id = room_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/scenario_result.rb
+++ b/lib/line/bot/v2/webhook/model/scenario_result.rb
@@ -30,7 +30,8 @@ module Line
             result_code:,
             action_results: nil,
             ble_notification_payload: nil,
-            error_reason: nil
+            error_reason: nil,
+            **dynamic_attributes
           )
             
             @scenario_id = scenario_id
@@ -41,6 +42,11 @@ module Line
             @action_results = action_results
             @ble_notification_payload = ble_notification_payload
             @error_reason = error_reason
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/scenario_result_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/scenario_result_things_content.rb
@@ -21,12 +21,18 @@ module Line
           def initialize(
             type:,
             device_id:,
-            result:
+            result:,
+            **dynamic_attributes
           )
             @type = "scenarioResult"
             
             @device_id = device_id
             @result = result
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/source.rb
+++ b/lib/line/bot/v2/webhook/model/source.rb
@@ -17,10 +17,16 @@ module Line
           attr_accessor :type # source type
 
           def initialize(
-            type: nil
+            type: nil,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/sticker_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/sticker_message_content.rb
@@ -34,7 +34,8 @@ module Line
             keywords: nil,
             text: nil,
             quote_token:,
-            quoted_message_id: nil
+            quoted_message_id: nil,
+            **dynamic_attributes
           )
             @type = "sticker"
             
@@ -46,6 +47,11 @@ module Line
             @text = text
             @quote_token = quote_token
             @quoted_message_id = quoted_message_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/text_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/text_message_content.rb
@@ -29,7 +29,8 @@ module Line
             emojis: nil,
             mention: nil,
             quote_token:,
-            quoted_message_id: nil
+            quoted_message_id: nil,
+            **dynamic_attributes
           )
             @type = "text"
             
@@ -39,6 +40,11 @@ module Line
             @mention = mention
             @quote_token = quote_token
             @quoted_message_id = quoted_message_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/things_content.rb
+++ b/lib/line/bot/v2/webhook/model/things_content.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :type # Type
 
           def initialize(
-            type:
+            type:,
+            **dynamic_attributes
           )
             
             @type = type
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/things_event.rb
+++ b/lib/line/bot/v2/webhook/model/things_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token:,
-            things:
+            things:,
+            **dynamic_attributes
           )
             @type = "things"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @things = things
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unfollow_event.rb
+++ b/lib/line/bot/v2/webhook/model/unfollow_event.rb
@@ -28,7 +28,8 @@ module Line
             timestamp:,
             mode:,
             webhook_event_id:,
-            delivery_context:
+            delivery_context:,
+            **dynamic_attributes
           )
             @type = "unfollow"
             
@@ -37,6 +38,11 @@ module Line
             @mode = mode
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unlink_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/unlink_things_content.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             type:,
-            device_id:
+            device_id:,
+            **dynamic_attributes
           )
             @type = "unlink"
             
             @device_id = device_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unsend_detail.rb
+++ b/lib/line/bot/v2/webhook/model/unsend_detail.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :message_id # The message ID of the unsent message
 
           def initialize(
-            message_id:
+            message_id:,
+            **dynamic_attributes
           )
             
             @message_id = message_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unsend_event.rb
+++ b/lib/line/bot/v2/webhook/model/unsend_event.rb
@@ -30,7 +30,8 @@ module Line
             mode:,
             webhook_event_id:,
             delivery_context:,
-            unsend:
+            unsend:,
+            **dynamic_attributes
           )
             @type = "unsend"
             
@@ -40,6 +41,11 @@ module Line
             @webhook_event_id = webhook_event_id
             @delivery_context = delivery_context
             @unsend = unsend
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/user_mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/user_mentionee.rb
@@ -26,7 +26,8 @@ module Line
             index:,
             length:,
             user_id: nil,
-            is_self: nil
+            is_self: nil,
+            **dynamic_attributes
           )
             @type = "user"
             
@@ -34,6 +35,11 @@ module Line
             @length = length
             @user_id = user_id
             @is_self = is_self
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/user_source.rb
+++ b/lib/line/bot/v2/webhook/model/user_source.rb
@@ -19,11 +19,17 @@ module Line
 
           def initialize(
             type:,
-            user_id: nil
+            user_id: nil,
+            **dynamic_attributes
           )
             @type = "user"
             
             @user_id = user_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/video_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/video_message_content.rb
@@ -25,7 +25,8 @@ module Line
             id:,
             duration: nil,
             content_provider:,
-            quote_token:
+            quote_token:,
+            **dynamic_attributes
           )
             @type = "video"
             
@@ -33,6 +34,11 @@ module Line
             @duration = duration
             @content_provider = content_provider
             @quote_token = quote_token
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/video_play_complete.rb
+++ b/lib/line/bot/v2/webhook/model/video_play_complete.rb
@@ -15,10 +15,16 @@ module Line
           attr_accessor :tracking_id # ID used to identify a video. Returns the same value as the trackingId assigned to the video message.
 
           def initialize(
-            tracking_id:
+            tracking_id:,
+            **dynamic_attributes
           )
             
             @tracking_id = tracking_id
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/video_play_complete_event.rb
+++ b/lib/line/bot/v2/webhook/model/video_play_complete_event.rb
@@ -32,7 +32,8 @@ module Line
             webhook_event_id:,
             delivery_context:,
             reply_token:,
-            video_play_complete:
+            video_play_complete:,
+            **dynamic_attributes
           )
             @type = "videoPlayComplete"
             
@@ -43,6 +44,11 @@ module Line
             @delivery_context = delivery_context
             @reply_token = reply_token
             @video_play_complete = video_play_complete
+
+            dynamic_attributes.each do |key, value|
+              self.class.attr_accessor key
+              instance_variable_set("@#{key}", value)
+            end
           end
         end
       end


### PR DESCRIPTION
To avoid parsing failures when undefined fields are present.
In particular, the goal is to avoid errors when the API adds a new field to the http response, but the SDK does not support it.