### PR TITLE
Fix handling snake_case form params

### DIFF
--- a/lib/line/bot/v2/utils.rb
+++ b/lib/line/bot/v2/utils.rb
@@ -21,15 +21,13 @@ module Line
           if object.is_a?(Array)
             object.map { |item| deep_to_hash(item) }
           elsif object.is_a?(Hash)
-            object.
-              transform_keys { |k| camelize(k) }.
-              transform_values { |v| deep_to_hash(v) }
+            object.transform_keys(&:to_sym).transform_values { |v| deep_to_hash(v) }
           elsif object.instance_variables.empty?
             object
           else
             object.instance_variables.each_with_object({}) do |var, hash|
               value = object.instance_variable_get(var)
-              key = camelize(var.to_s.delete('@')).to_sym
+              key = var.to_s.delete('@').to_sym
               hash[key] = deep_to_hash(value)
             end
           end

--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -231,7 +231,7 @@ describe 'misc' do
     it "doesn't require bearer token" do
       stub_request(:post, "https://api.line.me/v2/oauth/accessToken")
         .with(
-          body: { "clientId" => "test-client-id", "clientSecret" => "test-client-secret", "grantType" => "client_credentials" }
+          body: { client_id: "test-client-id", client_secret: "test-client-secret", grant_type: "client_credentials" }
         )
         .to_return(status: response_code, body: response_body, headers: { 'Content-Type' => 'application/json' })
 

--- a/spec/line/bot/v2/utils_spec.rb
+++ b/spec/line/bot/v2/utils_spec.rb
@@ -71,9 +71,9 @@ describe Line::Bot::V2::Utils do
   end
 
   describe '.deep_to_hash' do
-    it 'converts an object with instance variables to a hash with camelCase keys' do
+    it 'converts an object with instance variables to a hash' do
       input = TestObject.new('John', 'Doe')
-      expected_output = { firstName: 'John', lastName: 'Doe' }
+      expected_output = { first_name: 'John', last_name: 'Doe' }
       expect(Line::Bot::V2::Utils.deep_to_hash(input)).to eq(expected_output)
     end
 


### PR DESCRIPTION
Fixed some endpoints accepting parameters in snake_case instead of camelCase, and their handling was incorrect.

There were three places where `#deep_to_hash` was changed, and two were camelized incorrectly.
The remaining one needs to be caramelized, but it was camelized outside the method, so that's no problem.
https://github.com/line/line-bot-sdk-ruby/blob/336cafa21e135c4d5888eab42d63bb643f43a4d2/lib/line/bot/v2/http_client.rb#L65-L67