### PR TITLE
Fix item of hash behavior of deep_camelize

### DIFF
--- a/lib/line/bot/v2/utils.rb
+++ b/lib/line/bot/v2/utils.rb
@@ -33,13 +33,18 @@ module Line
           end
         end
 
-        def self.deep_camelize(hash)
-          return hash unless hash.is_a?(Hash)
-
-          hash.each_with_object({}) do |(k, v), new_hash|
-            camel_key = camelize(k).to_sym
-            new_value = v.is_a?(Hash) ? deep_camelize(v) : v
-            new_hash[camel_key] = new_value
+        def self.deep_camelize(object)
+          case object
+          when Array
+            object.map { |item| deep_camelize(item) }
+          when Hash
+            object.each_with_object({}) do |(k, v), new_object|
+              camel_key = camelize(k).to_sym
+              new_value = v.is_a?(Array) || v.is_a?(Hash) ? deep_camelize(v) : v
+              new_object[camel_key] = new_value
+            end
+          else
+            object
           end
         end
 

--- a/spec/line/bot/v2/utils_spec.rb
+++ b/spec/line/bot/v2/utils_spec.rb
@@ -104,6 +104,12 @@ describe Line::Bot::V2::Utils do
       expect(Line::Bot::V2::Utils.deep_camelize(input)).to eq(expected_output)
     end
 
+    it 'converts hashes in array with snake_case keys' do
+      input = [{ outer_key: { inner_key: 'value', inner_array: [{ core_key: 'value' }] } }]
+      expected_output = [{ outerKey: { innerKey: 'value', innerArray: [{ coreKey: 'value' }] } }]
+      expect(Line::Bot::V2::Utils.deep_camelize(input)).to eq(expected_output)
+    end
+
     it 'handles empty hashes' do
       input = {}
       expected_output = {}


### PR DESCRIPTION
Fix `#deep_camelize` which only supports `Hash` and omits `Array` consideration.
This will be fixed https://github.com/line/line-bot-sdk-ruby/pull/450#discussion_r2025839171.