### PR TITLE
Support for dynamic initialization of nested classes

### DIFF
--- a/generator/src/main/java/line/bot/generator/LineBotSdkRubyGenerator.java
+++ b/generator/src/main/java/line/bot/generator/LineBotSdkRubyGenerator.java
@@ -2,8 +2,10 @@ package line.bot.generator;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.openapitools.codegen.CodegenDiscriminator;
 import org.openapitools.codegen.CodegenModel;
@@ -79,6 +81,7 @@ public class LineBotSdkRubyGenerator extends AbstractRubyCodegen {
         for (ModelsMap entry : result.values()) {
             for (ModelMap mo : entry.getModels()) {
                 CodegenModel cm = mo.getModel();
+                final Map<String, Object> selector = new HashMap<>();
 
                 if (cm.getParentModel() != null) {
                     final CodegenDiscriminator discriminator = cm.getParentModel().getDiscriminator();
@@ -86,11 +89,33 @@ public class LineBotSdkRubyGenerator extends AbstractRubyCodegen {
                             it -> it.getModelName().equals(cm.name)
                     ).map(CodegenDiscriminator.MappedModel::getMappingName).findFirst();
                     mappingNameOptional.ifPresent(mappingName -> {
-                        final Map<String, Object> selector = new HashMap<>();
                         selector.put("propertyName", discriminator.getPropertyName());
                         selector.put("mappingName", mappingName);
                         cm.getVendorExtensions().put("x-selector", selector);
                     });
+                }
+
+                if (cm.getChildren() != null && cm.getDiscriminator() != null) {
+                    final List<Map<String, String>> childMappings =
+                        cm.getChildren().stream()
+                            .map(child -> {
+                                Map<String, String> childInfo = new HashMap<>();
+                                childInfo.put("className", child.name);
+
+                                final CodegenDiscriminator discriminator = cm.getDiscriminator();
+                                if (discriminator != null) {
+                                    discriminator.getMappedModels().stream()
+                                                 .filter(mappedModel -> mappedModel.getModelName().equals(child.name))
+                                                 .findFirst()
+                                                 .ifPresent(mappedModel -> childInfo.put("typeName", mappedModel.getMappingName()));
+                                }
+
+                                return childInfo;
+                            })
+                            .collect(Collectors.toList());
+
+                    cm.getVendorExtensions().put("x-children", childMappings);
+                    cm.getVendorExtensions().put("x-discriminator-property", cm.getDiscriminator().getPropertyName());
                 }
             }
         }

--- a/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
@@ -25,20 +25,57 @@ module Line
           {% if model.model.vendorExtensions.get("x-selector").propertyName != property.name %}attr_accessor{% else %}attr_reader{% endif %} :{{ property.name }}{% if property.description != null %} # {{ property.description }}{% endif %}
           {%- endfor %}
 
-          def initialize({% for property in model.model.vars %}{% if model.model.vendorExtensions.get("x-selector").propertyName != property.name or packageName == 'webhook' %}
+          def initialize({% for property in model.model.vars %}{% if model.model.vendorExtensions.get("x-selector").propertyName != property.name %}
             {{ property.name }}:{% if property.defaultValue == null %}{{ property.required ? '' : ' nil'  }}{% else %}{{ ' ' + property.defaultValue }}{% endif %},{% endif %}{% endfor %}
             **dynamic_attributes
           )
-            {% if model.model.vendorExtensions.get("x-selector") != null %}@{{model.model.vendorExtensions.get("x-selector").propertyName}} = "{{model.model.vendorExtensions.get("x-selector").mappingName}}"{% endif -%}
+            {% if model.model.vendorExtensions.get("x-selector") != null %}@{{model.model.vendorExtensions.get("x-selector").propertyName}} = "{{model.model.vendorExtensions.get("x-selector").mappingName}}"{%- endif -%}
             {%- for property in model.model.vars %}
-            {% if model.model.vendorExtensions.get("x-selector").propertyName != property.name %}@{{ property.name }} = {{ property.name }}{% endif -%}
-            {% endfor %}
+            {% if property.isArray -%}
+            @{{ property.name }} = {{ property.name }}{{ property.required ? '' : '&'  }}.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::{{ packageName | camelize }}::{{ property.complexType }}.create(**item)
+              else
+                item
+              end
+            end
+            {%- elseif property.isModel -%}
+            @{{ property.name }} = {{ property.name }}.is_a?(Line::Bot::V2::{{ packageName | camelize }}::{{ property.baseType }}){% if not property.required %} || {{ property.name }}.nil?{% endif %} ? {{ property.name }} : Line::Bot::V2::{{ packageName | camelize }}::{{ property.baseType }}.create(**{{ property.name }})
+            {%- elseif model.model.vendorExtensions.get("x-selector").propertyName != property.name -%}
+            @{{ property.name }} = {{ property.name }}
+            {%- endif -%}
+            {%- endfor %}
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
           end
+
+          def self.create(args){% if model.model.vendorExtensions.get("x-children") != null and model.model.vendorExtensions.get("x-discriminator-property") != null %}
+            klass = detect_class(args[:{{ model.model.vendorExtensions.get("x-discriminator-property") }}])
+            return klass.new(**args) if klass
+            {% endif %}
+            return new(**args)
+          end
+          {%- if model.model.vendorExtensions.get("x-children") != null %}
+
+          private
+
+          def self.detect_class(type)
+            {
+              {%- for child in model.model.vendorExtensions.get("x-children") %}
+              {{ child.typeName }}: Line::Bot::V2::{{ packageName | camelize }}::{{ child.className }},
+              {%- endfor %}
+            }[type.to_sym]
+          end{% endif %}
         end
       end
     end

--- a/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/model.pebble
@@ -58,6 +58,14 @@ module Line
             {% endif %}{{ loop.last ? '' : ",
             " }}{% endif %}{% endfor %}
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> {{ model.model.classname }}
+          {%- if model.model.vendorExtensions.get("x-children") != null %}
+
+          private
+
+          def self.detect_class: (type: String) -> Class
+          {%- endif %}
           {%- endif %}
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
@@ -21,12 +21,29 @@ module Line
             **dynamic_attributes
           )
             
-            @kids = kids
+            @kids = kids.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::ChannelAccessToken::string.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/error_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/error_response.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rb
@@ -34,8 +34,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rb
@@ -31,8 +31,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rb
@@ -31,8 +31,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/age_tile.rb
+++ b/lib/line/bot/v2/insight/model/age_tile.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/app_type_tile.rb
+++ b/lib/line/bot/v2/insight/model/app_type_tile.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/area_tile.rb
+++ b/lib/line/bot/v2/insight/model/area_tile.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/error_detail.rb
+++ b/lib/line/bot/v2/insight/model/error_detail.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/error_response.rb
+++ b/lib/line/bot/v2/insight/model/error_response.rb
@@ -23,12 +23,29 @@ module Line
           )
             
             @message = message
-            @details = details
+            @details = details&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::ErrorDetail.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/gender_tile.rb
+++ b/lib/line/bot/v2/insight/model/gender_tile.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_friends_demographics_response.rb
+++ b/lib/line/bot/v2/insight/model/get_friends_demographics_response.rb
@@ -32,16 +32,57 @@ module Line
           )
             
             @available = available
-            @genders = genders
-            @ages = ages
-            @areas = areas
-            @app_types = app_types
-            @subscription_periods = subscription_periods
+            @genders = genders&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::GenderTile.create(**item)
+              else
+                item
+              end
+            end
+            @ages = ages&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::AgeTile.create(**item)
+              else
+                item
+              end
+            end
+            @areas = areas&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::AreaTile.create(**item)
+              else
+                item
+              end
+            end
+            @app_types = app_types&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::AppTypeTile.create(**item)
+              else
+                item
+              end
+            end
+            @subscription_periods = subscription_periods&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::SubscriptionPeriodTile.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response.rb
@@ -25,14 +25,37 @@ module Line
             **dynamic_attributes
           )
             
-            @overview = overview
-            @messages = messages
-            @clicks = clicks
+            @overview = overview.is_a?(Line::Bot::V2::Insight::GetMessageEventResponseOverview) || overview.nil? ? overview : Line::Bot::V2::Insight::GetMessageEventResponseOverview.create(**overview)
+            @messages = messages&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::GetMessageEventResponseMessage.create(**item)
+              else
+                item
+              end
+            end
+            @clicks = clicks&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::GetMessageEventResponseClick.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response_click.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_click.rb
@@ -35,8 +35,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response_message.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_message.rb
@@ -56,8 +56,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_message_event_response_overview.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_overview.rb
@@ -42,8 +42,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_number_of_followers_response.rb
+++ b/lib/line/bot/v2/insight/model/get_number_of_followers_response.rb
@@ -34,8 +34,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rb
+++ b/lib/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rb
@@ -55,8 +55,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response.rb
@@ -25,14 +25,37 @@ module Line
             **dynamic_attributes
           )
             
-            @overview = overview
-            @messages = messages
-            @clicks = clicks
+            @overview = overview.is_a?(Line::Bot::V2::Insight::GetStatisticsPerUnitResponseOverview) ? overview : Line::Bot::V2::Insight::GetStatisticsPerUnitResponseOverview.create(**overview)
+            @messages = messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::GetStatisticsPerUnitResponseMessage.create(**item)
+              else
+                item
+              end
+            end
+            @clicks = clicks.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Insight::GetStatisticsPerUnitResponseClick.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rb
@@ -36,8 +36,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rb
@@ -60,8 +60,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rb
@@ -34,8 +34,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/insight/model/subscription_period_tile.rb
+++ b/lib/line/bot/v2/insight/model/subscription_period_tile.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/add_liff_app_response.rb
+++ b/lib/line/bot/v2/liff/model/add_liff_app_response.rb
@@ -23,8 +23,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/get_all_liff_apps_response.rb
+++ b/lib/line/bot/v2/liff/model/get_all_liff_apps_response.rb
@@ -19,12 +19,29 @@ module Line
             **dynamic_attributes
           )
             
-            @apps = apps
+            @apps = apps&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Liff::LiffApp.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_app.rb
+++ b/lib/line/bot/v2/liff/model/liff_app.rb
@@ -32,17 +32,34 @@ module Line
           )
             
             @liff_id = liff_id
-            @view = view
+            @view = view.is_a?(Line::Bot::V2::Liff::LiffView) || view.nil? ? view : Line::Bot::V2::Liff::LiffView.create(**view)
             @description = description
-            @features = features
+            @features = features.is_a?(Line::Bot::V2::Liff::LiffFeatures) || features.nil? ? features : Line::Bot::V2::Liff::LiffFeatures.create(**features)
             @permanent_link_pattern = permanent_link_pattern
-            @scope = scope
+            @scope = scope&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Liff::LiffScope.create(**item)
+              else
+                item
+              end
+            end
             @bot_prompt = bot_prompt
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_bot_prompt.rb
+++ b/lib/line/bot/v2/liff/model/liff_bot_prompt.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_features.rb
+++ b/lib/line/bot/v2/liff/model/liff_features.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_scope.rb
+++ b/lib/line/bot/v2/liff/model/liff_scope.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/liff_view.rb
+++ b/lib/line/bot/v2/liff/model/liff_view.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/update_liff_app_request.rb
+++ b/lib/line/bot/v2/liff/model/update_liff_app_request.rb
@@ -30,17 +30,34 @@ module Line
             **dynamic_attributes
           )
             
-            @view = view
+            @view = view.is_a?(Line::Bot::V2::Liff::UpdateLiffView) || view.nil? ? view : Line::Bot::V2::Liff::UpdateLiffView.create(**view)
             @description = description
-            @features = features
+            @features = features.is_a?(Line::Bot::V2::Liff::LiffFeatures) || features.nil? ? features : Line::Bot::V2::Liff::LiffFeatures.create(**features)
             @permanent_link_pattern = permanent_link_pattern
-            @scope = scope
+            @scope = scope&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Liff::LiffScope.create(**item)
+              else
+                item
+              end
+            end
             @bot_prompt = bot_prompt
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/liff/model/update_liff_view.rb
+++ b/lib/line/bot/v2/liff/model/update_liff_view.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/adaccount.rb
+++ b/lib/line/bot/v2/manage_audience/model/adaccount.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rb
@@ -27,12 +27,29 @@ module Line
             
             @audience_group_id = audience_group_id
             @upload_description = upload_description
-            @audiences = audiences
+            @audiences = audiences&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::ManageAudience::Audience.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group.rb
@@ -57,8 +57,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_authority_level.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_authority_level.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_create_route.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_create_route.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_failed_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_failed_type.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job.rb
@@ -46,8 +46,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job_failed_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job_failed_type.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job_status.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job_status.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job_type.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_permission.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_permission.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_status.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_status.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/audience_group_type.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_type.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_audience_group_request.rb
@@ -30,12 +30,29 @@ module Line
             @description = description
             @is_ifa_audience = is_ifa_audience
             @upload_description = upload_description
-            @audiences = audiences
+            @audiences = audiences&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::ManageAudience::Audience.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_audience_group_response.rb
@@ -46,8 +46,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rb
@@ -31,8 +31,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rb
@@ -52,8 +52,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rb
@@ -28,8 +28,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rb
@@ -37,8 +37,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/detailed_owner.rb
+++ b/lib/line/bot/v2/manage_audience/model/detailed_owner.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/error_detail.rb
+++ b/lib/line/bot/v2/manage_audience/model/error_detail.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/error_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/error_response.rb
@@ -23,12 +23,29 @@ module Line
           )
             
             @message = message
-            @details = details
+            @details = details&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::ManageAudience::ErrorDetail.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_audience_data_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_audience_data_response.rb
@@ -25,14 +25,31 @@ module Line
             **dynamic_attributes
           )
             
-            @audience_group = audience_group
-            @jobs = jobs
-            @adaccount = adaccount
+            @audience_group = audience_group.is_a?(Line::Bot::V2::ManageAudience::AudienceGroup) || audience_group.nil? ? audience_group : Line::Bot::V2::ManageAudience::AudienceGroup.create(**audience_group)
+            @jobs = jobs&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::ManageAudience::AudienceGroupJob.create(**item)
+              else
+                item
+              end
+            end
+            @adaccount = adaccount.is_a?(Line::Bot::V2::ManageAudience::Adaccount) || adaccount.nil? ? adaccount : Line::Bot::V2::ManageAudience::Adaccount.create(**adaccount)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_audience_group_authority_level_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_audience_group_authority_level_response.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rb
@@ -25,14 +25,31 @@ module Line
             **dynamic_attributes
           )
             
-            @audience_group = audience_group
-            @jobs = jobs
-            @owner = owner
+            @audience_group = audience_group.is_a?(Line::Bot::V2::ManageAudience::AudienceGroup) || audience_group.nil? ? audience_group : Line::Bot::V2::ManageAudience::AudienceGroup.create(**audience_group)
+            @jobs = jobs&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::ManageAudience::AudienceGroupJob.create(**item)
+              else
+                item
+              end
+            end
+            @owner = owner.is_a?(Line::Bot::V2::ManageAudience::DetailedOwner) || owner.nil? ? owner : Line::Bot::V2::ManageAudience::DetailedOwner.create(**owner)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/update_audience_group_authority_level_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/update_audience_group_authority_level_request.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/manage_audience/model/update_audience_group_description_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/update_audience_group_description_request.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/age_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/age_demographic.rb
@@ -20,8 +20,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/age_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/age_demographic_filter.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/all_mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/all_mention_target.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/alt_uri.rb
+++ b/lib/line/bot/v2/messaging_api/model/alt_uri.rb
@@ -23,8 +23,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/app_type_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/app_type_demographic.rb
@@ -20,8 +20,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
@@ -23,12 +23,29 @@ module Line
           )
             @type = "appType"
             
-            @one_of = one_of
+            @one_of = one_of&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::AppTypeDemographic.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/area_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/area_demographic.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
@@ -23,12 +23,29 @@ module Line
           )
             @type = "area"
             
-            @one_of = one_of
+            @one_of = one_of&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::AreaDemographic.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/audience_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/audience_recipient.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/audio_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/audio_message.rb
@@ -30,15 +30,26 @@ module Line
           )
             @type = "audio"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @original_content_url = original_content_url
             @duration = duration
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/bot_info_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/bot_info_response.rb
@@ -42,8 +42,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/broadcast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/broadcast_request.rb
@@ -22,13 +22,30 @@ module Line
             **dynamic_attributes
           )
             
-            @messages = messages
+            @messages = messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Message.create(**item)
+              else
+                item
+              end
+            end
             @notification_disabled = notification_disabled
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/buttons_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/buttons_template.rb
@@ -43,13 +43,30 @@ module Line
             @image_background_color = image_background_color
             @title = title
             @text = text
-            @default_action = default_action
-            @actions = actions
+            @default_action = default_action.is_a?(Line::Bot::V2::MessagingApi::Action) || default_action.nil? ? default_action : Line::Bot::V2::MessagingApi::Action.create(**default_action)
+            @actions = actions.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Action.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/camera_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/camera_action.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/camera_roll_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/camera_roll_action.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/carousel_column.rb
+++ b/lib/line/bot/v2/messaging_api/model/carousel_column.rb
@@ -34,13 +34,30 @@ module Line
             @image_background_color = image_background_color
             @title = title
             @text = text
-            @default_action = default_action
-            @actions = actions
+            @default_action = default_action.is_a?(Line::Bot::V2::MessagingApi::Action) || default_action.nil? ? default_action : Line::Bot::V2::MessagingApi::Action.create(**default_action)
+            @actions = actions.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Action.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/carousel_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/carousel_template.rb
@@ -27,14 +27,31 @@ module Line
           )
             @type = "carousel"
             
-            @columns = columns
+            @columns = columns.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::CarouselColumn.create(**item)
+              else
+                item
+              end
+            end
             @image_aspect_ratio = image_aspect_ratio
             @image_size = image_size
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/chat_reference.rb
+++ b/lib/line/bot/v2/messaging_api/model/chat_reference.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/clipboard_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/clipboard_action.rb
@@ -31,8 +31,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rb
@@ -28,14 +28,25 @@ module Line
           )
             @type = "clipboard"
             
-            @area = area
+            @area = area.is_a?(Line::Bot::V2::MessagingApi::ImagemapArea) ? area : Line::Bot::V2::MessagingApi::ImagemapArea.create(**area)
             @clipboard_text = clipboard_text
             @label = label
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/confirm_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/confirm_template.rb
@@ -26,12 +26,29 @@ module Line
             @type = "confirm"
             
             @text = text
-            @actions = actions
+            @actions = actions.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Action.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/datetime_picker_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/datetime_picker_action.rb
@@ -43,8 +43,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/demographic_filter.rb
@@ -24,8 +24,35 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              age: Line::Bot::V2::MessagingApi::AgeDemographicFilter,
+              appType: Line::Bot::V2::MessagingApi::AppTypeDemographicFilter,
+              area: Line::Bot::V2::MessagingApi::AreaDemographicFilter,
+              gender: Line::Bot::V2::MessagingApi::GenderDemographicFilter,
+              operator: Line::Bot::V2::MessagingApi::OperatorDemographicFilter,
+              subscriptionPeriod: Line::Bot::V2::MessagingApi::SubscriptionPeriodDemographicFilter,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/emoji.rb
+++ b/lib/line/bot/v2/messaging_api/model/emoji.rb
@@ -29,8 +29,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/emoji_substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/emoji_substitution_object.rb
@@ -32,8 +32,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/error_detail.rb
+++ b/lib/line/bot/v2/messaging_api/model/error_detail.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/error_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/error_response.rb
@@ -25,13 +25,36 @@ module Line
           )
             
             @message = message
-            @details = details
-            @sent_messages = sent_messages
+            @details = details&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::ErrorDetail.create(**item)
+              else
+                item
+              end
+            end
+            @sent_messages = sent_messages&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::SentMessage.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/filter.rb
@@ -20,12 +20,23 @@ module Line
             **dynamic_attributes
           )
             
-            @demographic = demographic
+            @demographic = demographic.is_a?(Line::Bot::V2::MessagingApi::DemographicFilter) || demographic.nil? ? demographic : Line::Bot::V2::MessagingApi::DemographicFilter.create(**demographic)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_block_style.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_block_style.rb
@@ -29,8 +29,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_background.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_background.rb
@@ -23,8 +23,30 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              linearGradient: Line::Bot::V2::MessagingApi::FlexBoxLinearGradient,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_border_width.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_border_width.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_corner_radius.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_corner_radius.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rb
@@ -39,8 +39,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_padding.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_padding.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_box_spacing.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_spacing.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_bubble.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_bubble.rb
@@ -38,18 +38,29 @@ module Line
             @type = "bubble"
             
             @direction = direction
-            @styles = styles
-            @header = header
-            @hero = hero
-            @body = body
-            @footer = footer
+            @styles = styles.is_a?(Line::Bot::V2::MessagingApi::FlexBubbleStyles) || styles.nil? ? styles : Line::Bot::V2::MessagingApi::FlexBubbleStyles.create(**styles)
+            @header = header.is_a?(Line::Bot::V2::MessagingApi::FlexBox) || header.nil? ? header : Line::Bot::V2::MessagingApi::FlexBox.create(**header)
+            @hero = hero.is_a?(Line::Bot::V2::MessagingApi::FlexComponent) || hero.nil? ? hero : Line::Bot::V2::MessagingApi::FlexComponent.create(**hero)
+            @body = body.is_a?(Line::Bot::V2::MessagingApi::FlexBox) || body.nil? ? body : Line::Bot::V2::MessagingApi::FlexBox.create(**body)
+            @footer = footer.is_a?(Line::Bot::V2::MessagingApi::FlexBox) || footer.nil? ? footer : Line::Bot::V2::MessagingApi::FlexBox.create(**footer)
             @size = size
-            @action = action
+            @action = action.is_a?(Line::Bot::V2::MessagingApi::Action) || action.nil? ? action : Line::Bot::V2::MessagingApi::Action.create(**action)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_bubble_styles.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_bubble_styles.rb
@@ -25,15 +25,26 @@ module Line
             **dynamic_attributes
           )
             
-            @header = header
-            @hero = hero
-            @body = body
-            @footer = footer
+            @header = header.is_a?(Line::Bot::V2::MessagingApi::FlexBlockStyle) || header.nil? ? header : Line::Bot::V2::MessagingApi::FlexBlockStyle.create(**header)
+            @hero = hero.is_a?(Line::Bot::V2::MessagingApi::FlexBlockStyle) || hero.nil? ? hero : Line::Bot::V2::MessagingApi::FlexBlockStyle.create(**hero)
+            @body = body.is_a?(Line::Bot::V2::MessagingApi::FlexBlockStyle) || body.nil? ? body : Line::Bot::V2::MessagingApi::FlexBlockStyle.create(**body)
+            @footer = footer.is_a?(Line::Bot::V2::MessagingApi::FlexBlockStyle) || footer.nil? ? footer : Line::Bot::V2::MessagingApi::FlexBlockStyle.create(**footer)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_button.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_button.rb
@@ -52,7 +52,7 @@ module Line
             @flex = flex
             @color = color
             @style = style
-            @action = action
+            @action = action.is_a?(Line::Bot::V2::MessagingApi::Action) ? action : Line::Bot::V2::MessagingApi::Action.create(**action)
             @gravity = gravity
             @margin = margin
             @position = position
@@ -66,8 +66,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_carousel.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_carousel.rb
@@ -23,12 +23,29 @@ module Line
           )
             @type = "carousel"
             
-            @contents = contents
+            @contents = contents.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::FlexBubble.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_component.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_component.rb
@@ -23,8 +23,38 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              box: Line::Bot::V2::MessagingApi::FlexBox,
+              button: Line::Bot::V2::MessagingApi::FlexButton,
+              filler: Line::Bot::V2::MessagingApi::FlexFiller,
+              icon: Line::Bot::V2::MessagingApi::FlexIcon,
+              image: Line::Bot::V2::MessagingApi::FlexImage,
+              separator: Line::Bot::V2::MessagingApi::FlexSeparator,
+              span: Line::Bot::V2::MessagingApi::FlexSpan,
+              text: Line::Bot::V2::MessagingApi::FlexText,
+              video: Line::Bot::V2::MessagingApi::FlexVideo,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_container.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_container.rb
@@ -23,8 +23,31 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              bubble: Line::Bot::V2::MessagingApi::FlexBubble,
+              carousel: Line::Bot::V2::MessagingApi::FlexCarousel,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_filler.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_filler.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_icon.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_icon.rb
@@ -55,8 +55,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_icon_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_icon_size.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_image.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_image.rb
@@ -68,13 +68,24 @@ module Line
             @aspect_ratio = aspect_ratio
             @aspect_mode = aspect_mode
             @background_color = background_color
-            @action = action
+            @action = action.is_a?(Line::Bot::V2::MessagingApi::Action) || action.nil? ? action : Line::Bot::V2::MessagingApi::Action.create(**action)
             @animated = animated
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_image_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_image_size.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_margin.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_margin.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_message.rb
@@ -30,15 +30,26 @@ module Line
           )
             @type = "flex"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @alt_text = alt_text
-            @contents = contents
+            @contents = contents.is_a?(Line::Bot::V2::MessagingApi::FlexContainer) ? contents : Line::Bot::V2::MessagingApi::FlexContainer.create(**contents)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_offset.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_offset.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_separator.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_separator.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_span.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_span.rb
@@ -42,8 +42,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_span_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_span_size.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_text_font_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_text_font_size.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/flex_video.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_video.rb
@@ -33,14 +33,25 @@ module Line
             
             @url = url
             @preview_url = preview_url
-            @alt_content = alt_content
+            @alt_content = alt_content.is_a?(Line::Bot::V2::MessagingApi::FlexComponent) ? alt_content : Line::Bot::V2::MessagingApi::FlexComponent.create(**alt_content)
             @aspect_ratio = aspect_ratio
-            @action = action
+            @action = action.is_a?(Line::Bot::V2::MessagingApi::Action) || action.nil? ? action : Line::Bot::V2::MessagingApi::Action.create(**action)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/gender_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/gender_demographic.rb
@@ -20,8 +20,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
@@ -23,12 +23,29 @@ module Line
           )
             @type = "gender"
             
-            @one_of = one_of
+            @one_of = one_of&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::GenderDemographic.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
@@ -22,13 +22,30 @@ module Line
             **dynamic_attributes
           )
             
-            @custom_aggregation_units = custom_aggregation_units
+            @custom_aggregation_units = custom_aggregation_units.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
             @_next = _next
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
@@ -22,13 +22,30 @@ module Line
             **dynamic_attributes
           )
             
-            @user_ids = user_ids
+            @user_ids = user_ids.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
             @_next = _next
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
@@ -23,13 +23,30 @@ module Line
             **dynamic_attributes
           )
             
-            @user_ids = user_ids
+            @user_ids = user_ids.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
             @_next = _next
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_membership_subscription_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_membership_subscription_response.rb
@@ -21,12 +21,29 @@ module Line
             **dynamic_attributes
           )
             
-            @subscriptions = subscriptions
+            @subscriptions = subscriptions.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Subscription.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/group_member_count_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_member_count_response.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/group_summary_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_summary_response.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/group_user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_user_profile_response.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/image_carousel_column.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_carousel_column.rb
@@ -22,12 +22,23 @@ module Line
           )
             
             @image_url = image_url
-            @action = action
+            @action = action.is_a?(Line::Bot::V2::MessagingApi::Action) ? action : Line::Bot::V2::MessagingApi::Action.create(**action)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/image_carousel_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_carousel_template.rb
@@ -23,12 +23,29 @@ module Line
           )
             @type = "image_carousel"
             
-            @columns = columns
+            @columns = columns.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::ImageCarouselColumn.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/image_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_message.rb
@@ -30,15 +30,26 @@ module Line
           )
             @type = "image"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @original_content_url = original_content_url
             @preview_image_url = preview_image_url
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_action.rb
@@ -23,12 +23,36 @@ module Line
           )
             
             @type = type
-            @area = area
+            @area = area.is_a?(Line::Bot::V2::MessagingApi::ImagemapArea) ? area : Line::Bot::V2::MessagingApi::ImagemapArea.create(**area)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              clipboard: Line::Bot::V2::MessagingApi::ClipboardImagemapAction,
+              message: Line::Bot::V2::MessagingApi::MessageImagemapAction,
+              uri: Line::Bot::V2::MessagingApi::URIImagemapAction,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_area.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_area.rb
@@ -32,8 +32,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_base_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_base_size.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_external_link.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_external_link.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/imagemap_video.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_video.rb
@@ -27,13 +27,24 @@ module Line
             
             @original_content_url = original_content_url
             @preview_image_url = preview_image_url
-            @area = area
-            @external_link = external_link
+            @area = area.is_a?(Line::Bot::V2::MessagingApi::ImagemapArea) || area.nil? ? area : Line::Bot::V2::MessagingApi::ImagemapArea.create(**area)
+            @external_link = external_link.is_a?(Line::Bot::V2::MessagingApi::ImagemapExternalLink) || external_link.nil? ? external_link : Line::Bot::V2::MessagingApi::ImagemapExternalLink.create(**external_link)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/issue_link_token_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/issue_link_token_response.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/limit.rb
+++ b/lib/line/bot/v2/messaging_api/model/limit.rb
@@ -28,8 +28,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/location_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/location_action.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/location_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/location_message.rb
@@ -34,8 +34,8 @@ module Line
           )
             @type = "location"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @title = title
             @address = address
             @latitude = latitude
@@ -43,8 +43,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rb
@@ -20,12 +20,23 @@ module Line
             **dynamic_attributes
           )
             
-            @chat = chat
+            @chat = chat.is_a?(Line::Bot::V2::MessagingApi::ChatReference) ? chat : Line::Bot::V2::MessagingApi::ChatReference.create(**chat)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
@@ -21,13 +21,30 @@ module Line
             **dynamic_attributes
           )
             
-            @member_ids = member_ids
+            @member_ids = member_ids.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
             @_next = _next
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/membership.rb
+++ b/lib/line/bot/v2/messaging_api/model/membership.rb
@@ -40,7 +40,13 @@ module Line
             @membership_id = membership_id
             @title = title
             @description = description
-            @benefits = benefits
+            @benefits = benefits.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
             @price = price
             @currency = currency
             @member_count = member_count
@@ -50,8 +56,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/membership_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/membership_list_response.rb
@@ -20,12 +20,29 @@ module Line
             **dynamic_attributes
           )
             
-            @memberships = memberships
+            @memberships = memberships.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Membership.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/mention_substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/mention_substitution_object.rb
@@ -25,12 +25,23 @@ module Line
           )
             @type = "mention"
             
-            @mentionee = mentionee
+            @mentionee = mentionee.is_a?(Line::Bot::V2::MessagingApi::MentionTarget) ? mentionee : Line::Bot::V2::MessagingApi::MentionTarget.create(**mentionee)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/mention_target.rb
@@ -23,8 +23,31 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              all: Line::Bot::V2::MessagingApi::AllMentionTarget,
+              user: Line::Bot::V2::MessagingApi::UserMentionTarget,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/message_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_action.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/message_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_imagemap_action.rb
@@ -27,14 +27,25 @@ module Line
           )
             @type = "message"
             
-            @area = area
+            @area = area.is_a?(Line::Bot::V2::MessagingApi::ImagemapArea) ? area : Line::Bot::V2::MessagingApi::ImagemapArea.create(**area)
             @text = text
             @label = label
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/message_quota_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_quota_response.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/multicast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/multicast_request.rb
@@ -26,15 +26,44 @@ module Line
             **dynamic_attributes
           )
             
-            @messages = messages
-            @to = to
+            @messages = messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Message.create(**item)
+              else
+                item
+              end
+            end
+            @to = to.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
             @notification_disabled = notification_disabled
-            @custom_aggregation_units = custom_aggregation_units
+            @custom_aggregation_units = custom_aggregation_units&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/narrowcast_progress_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/narrowcast_progress_response.rb
@@ -45,8 +45,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/number_of_messages_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/number_of_messages_response.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/operator_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/operator_demographic_filter.rb
@@ -27,14 +27,37 @@ module Line
           )
             @type = "operator"
             
-            @_and = _and
-            @_or = _or
-            @_not = _not
+            @_and = _and&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::DemographicFilter.create(**item)
+              else
+                item
+              end
+            end
+            @_or = _or&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::DemographicFilter.create(**item)
+              else
+                item
+              end
+            end
+            @_not = _not.is_a?(Line::Bot::V2::MessagingApi::DemographicFilter) || _not.nil? ? _not : Line::Bot::V2::MessagingApi::DemographicFilter.create(**_not)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/operator_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/operator_recipient.rb
@@ -27,14 +27,37 @@ module Line
           )
             @type = "operator"
             
-            @_and = _and
-            @_or = _or
-            @_not = _not
+            @_and = _and&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Recipient.create(**item)
+              else
+                item
+              end
+            end
+            @_or = _or&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Recipient.create(**item)
+              else
+                item
+              end
+            end
+            @_not = _not.is_a?(Line::Bot::V2::MessagingApi::Recipient) || _not.nil? ? _not : Line::Bot::V2::MessagingApi::Recipient.create(**_not)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/pnp_messages_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/pnp_messages_request.rb
@@ -24,14 +24,31 @@ module Line
             **dynamic_attributes
           )
             
-            @messages = messages
+            @messages = messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Message.create(**item)
+              else
+                item
+              end
+            end
             @to = to
             @notification_disabled = notification_disabled
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/postback_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/postback_action.rb
@@ -42,8 +42,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/push_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/push_message_request.rb
@@ -27,14 +27,37 @@ module Line
           )
             
             @to = to
-            @messages = messages
+            @messages = messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Message.create(**item)
+              else
+                item
+              end
+            end
             @notification_disabled = notification_disabled
-            @custom_aggregation_units = custom_aggregation_units
+            @custom_aggregation_units = custom_aggregation_units&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/push_message_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/push_message_response.rb
@@ -20,12 +20,29 @@ module Line
             **dynamic_attributes
           )
             
-            @sent_messages = sent_messages
+            @sent_messages = sent_messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::SentMessage.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quick_reply.rb
+++ b/lib/line/bot/v2/messaging_api/model/quick_reply.rb
@@ -21,12 +21,29 @@ module Line
             **dynamic_attributes
           )
             
-            @items = items
+            @items = items&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::QuickReplyItem.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quick_reply_item.rb
+++ b/lib/line/bot/v2/messaging_api/model/quick_reply_item.rb
@@ -25,13 +25,24 @@ module Line
           )
             
             @image_url = image_url
-            @action = action
+            @action = action.is_a?(Line::Bot::V2::MessagingApi::Action) || action.nil? ? action : Line::Bot::V2::MessagingApi::Action.create(**action)
             @type = type
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quota_consumption_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/quota_consumption_response.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/quota_type.rb
+++ b/lib/line/bot/v2/messaging_api/model/quota_type.rb
@@ -22,8 +22,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/recipient.rb
@@ -24,8 +24,32 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              audience: Line::Bot::V2::MessagingApi::AudienceRecipient,
+              operator: Line::Bot::V2::MessagingApi::OperatorRecipient,
+              redelivery: Line::Bot::V2::MessagingApi::RedeliveryRecipient,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/redelivery_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/redelivery_recipient.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/reply_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/reply_message_request.rb
@@ -25,13 +25,30 @@ module Line
           )
             
             @reply_token = reply_token
-            @messages = messages
+            @messages = messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Message.create(**item)
+              else
+                item
+              end
+            end
             @notification_disabled = notification_disabled
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/reply_message_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/reply_message_response.rb
@@ -20,12 +20,29 @@ module Line
             **dynamic_attributes
           )
             
-            @sent_messages = sent_messages
+            @sent_messages = sent_messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::SentMessage.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rb
@@ -20,12 +20,29 @@ module Line
             **dynamic_attributes
           )
             
-            @aliases = aliases
+            @aliases = aliases.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::RichMenuAliasResponse.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_alias_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_alias_response.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_area.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_area.rb
@@ -22,13 +22,24 @@ module Line
             **dynamic_attributes
           )
             
-            @bounds = bounds
-            @action = action
+            @bounds = bounds.is_a?(Line::Bot::V2::MessagingApi::RichMenuBounds) || bounds.nil? ? bounds : Line::Bot::V2::MessagingApi::RichMenuBounds.create(**bounds)
+            @action = action.is_a?(Line::Bot::V2::MessagingApi::Action) || action.nil? ? action : Line::Bot::V2::MessagingApi::Action.create(**action)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rb
@@ -31,8 +31,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rb
@@ -25,8 +25,32 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              link: Line::Bot::V2::MessagingApi::RichMenuBatchLinkOperation,
+              unlinkAll: Line::Bot::V2::MessagingApi::RichMenuBatchUnlinkAllOperation,
+              unlink: Line::Bot::V2::MessagingApi::RichMenuBatchUnlinkOperation,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_phase.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_phase.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_request.rb
@@ -21,13 +21,30 @@ module Line
             **dynamic_attributes
           )
             
-            @operations = operations
+            @operations = operations.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::RichMenuBatchOperation.create(**item)
+              else
+                item
+              end
+            end
             @resume_request_key = resume_request_key
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rb
@@ -28,8 +28,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bounds.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bounds.rb
@@ -34,8 +34,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
@@ -23,12 +23,29 @@ module Line
           )
             
             @rich_menu_id = rich_menu_id
-            @user_ids = user_ids
+            @user_ids = user_ids.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
@@ -20,12 +20,29 @@ module Line
             **dynamic_attributes
           )
             
-            @user_ids = user_ids
+            @user_ids = user_ids.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_id_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_id_response.rb
@@ -23,8 +23,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_list_response.rb
@@ -20,12 +20,29 @@ module Line
             **dynamic_attributes
           )
             
-            @richmenus = richmenus
+            @richmenus = richmenus.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::RichMenuResponse.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_response.rb
@@ -30,16 +30,33 @@ module Line
           )
             
             @rich_menu_id = rich_menu_id
-            @size = size
+            @size = size.is_a?(Line::Bot::V2::MessagingApi::RichMenuSize) ? size : Line::Bot::V2::MessagingApi::RichMenuSize.create(**size)
             @selected = selected
             @name = name
             @chat_bar_text = chat_bar_text
-            @areas = areas
+            @areas = areas.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::RichMenuArea.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_size.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_switch_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_switch_action.rb
@@ -33,8 +33,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/room_member_count_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/room_member_count_response.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/room_user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/room_user_profile_response.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/sender.rb
+++ b/lib/line/bot/v2/messaging_api/model/sender.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/sent_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/sent_message.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/show_loading_animation_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/show_loading_animation_request.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/sticker_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/sticker_message.rb
@@ -32,16 +32,27 @@ module Line
           )
             @type = "sticker"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @package_id = package_id
             @sticker_id = sticker_id
             @quote_token = quote_token
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
@@ -33,14 +33,31 @@ module Line
             @membership_id = membership_id
             @title = title
             @description = description
-            @benefits = benefits
+            @benefits = benefits.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::string.create(**item)
+              else
+                item
+              end
+            end
             @price = price
             @currency = currency
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscribed_membership_user.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscribed_membership_user.rb
@@ -33,8 +33,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscription.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription.rb
@@ -22,13 +22,24 @@ module Line
             **dynamic_attributes
           )
             
-            @membership = membership
-            @user = user
+            @membership = membership.is_a?(Line::Bot::V2::MessagingApi::SubscribedMembershipPlan) ? membership : Line::Bot::V2::MessagingApi::SubscribedMembershipPlan.create(**membership)
+            @user = user.is_a?(Line::Bot::V2::MessagingApi::SubscribedMembershipUser) ? user : Line::Bot::V2::MessagingApi::SubscribedMembershipUser.create(**user)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscription_period_demographic.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription_period_demographic.rb
@@ -20,8 +20,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/substitution_object.rb
@@ -24,8 +24,31 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              emoji: Line::Bot::V2::MessagingApi::EmojiSubstitutionObject,
+              mention: Line::Bot::V2::MessagingApi::MentionSubstitutionObject,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template.rb
+++ b/lib/line/bot/v2/messaging_api/model/template.rb
@@ -23,8 +23,33 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              buttons: Line::Bot::V2::MessagingApi::ButtonsTemplate,
+              carousel: Line::Bot::V2::MessagingApi::CarouselTemplate,
+              confirm: Line::Bot::V2::MessagingApi::ConfirmTemplate,
+              image_carousel: Line::Bot::V2::MessagingApi::ImageCarouselTemplate,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template_image_aspect_ratio.rb
+++ b/lib/line/bot/v2/messaging_api/model/template_image_aspect_ratio.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template_image_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/template_image_size.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/template_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/template_message.rb
@@ -30,15 +30,26 @@ module Line
           )
             @type = "template"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @alt_text = alt_text
-            @template = template
+            @template = template.is_a?(Line::Bot::V2::MessagingApi::Template) ? template : Line::Bot::V2::MessagingApi::Template.create(**template)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rb
@@ -36,8 +36,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/text_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/text_message.rb
@@ -32,16 +32,33 @@ module Line
           )
             @type = "text"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @text = text
-            @emojis = emojis
+            @emojis = emojis&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Emoji.create(**item)
+              else
+                item
+              end
+            end
             @quote_token = quote_token
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/text_message_v2.rb
+++ b/lib/line/bot/v2/messaging_api/model/text_message_v2.rb
@@ -32,16 +32,27 @@ module Line
           )
             @type = "textV2"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @text = text
             @substitution = substitution
             @quote_token = quote_token
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/uri_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/uri_action.rb
@@ -29,12 +29,23 @@ module Line
             
             @label = label
             @uri = uri
-            @alt_uri = alt_uri
+            @alt_uri = alt_uri.is_a?(Line::Bot::V2::MessagingApi::AltUri) || alt_uri.nil? ? alt_uri : Line::Bot::V2::MessagingApi::AltUri.create(**alt_uri)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/uri_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/uri_imagemap_action.rb
@@ -27,14 +27,25 @@ module Line
           )
             @type = "uri"
             
-            @area = area
+            @area = area.is_a?(Line::Bot::V2::MessagingApi::ImagemapArea) ? area : Line::Bot::V2::MessagingApi::ImagemapArea.create(**area)
             @link_uri = link_uri
             @label = label
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/user_mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/user_mention_target.rb
@@ -28,8 +28,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/user_profile_response.rb
@@ -36,8 +36,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/validate_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/validate_message_request.rb
@@ -19,12 +19,29 @@ module Line
             **dynamic_attributes
           )
             
-            @messages = messages
+            @messages = messages.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::MessagingApi::Message.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/messaging_api/model/video_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/video_message.rb
@@ -32,16 +32,27 @@ module Line
           )
             @type = "video"
             
-            @quick_reply = quick_reply
-            @sender = sender
+            @quick_reply = quick_reply.is_a?(Line::Bot::V2::MessagingApi::QuickReply) || quick_reply.nil? ? quick_reply : Line::Bot::V2::MessagingApi::QuickReply.create(**quick_reply)
+            @sender = sender.is_a?(Line::Bot::V2::MessagingApi::Sender) || sender.nil? ? sender : Line::Bot::V2::MessagingApi::Sender.create(**sender)
             @original_content_url = original_content_url
             @preview_image_url = preview_image_url
             @tracking_id = tracking_id
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/module/model/acquire_chat_control_request.rb
+++ b/lib/line/bot/v2/module/model/acquire_chat_control_request.rb
@@ -28,8 +28,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/module/model/detach_module_request.rb
+++ b/lib/line/bot/v2/module/model/detach_module_request.rb
@@ -25,8 +25,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/module/model/get_modules_response.rb
+++ b/lib/line/bot/v2/module/model/get_modules_response.rb
@@ -23,13 +23,30 @@ module Line
             **dynamic_attributes
           )
             
-            @bots = bots
+            @bots = bots.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Module::ModuleBot.create(**item)
+              else
+                item
+              end
+            end
             @_next = _next
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/module/model/module_bot.rb
+++ b/lib/line/bot/v2/module/model/module_bot.rb
@@ -37,8 +37,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/module_attach/model/attach_module_response.rb
+++ b/lib/line/bot/v2/module_attach/model/attach_module_response.rb
@@ -23,12 +23,29 @@ module Line
           )
             
             @bot_id = bot_id
-            @scopes = scopes
+            @scopes = scopes.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::ModuleAttach::string.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/shop/model/error_response.rb
+++ b/lib/line/bot/v2/shop/model/error_response.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/shop/model/mission_sticker_request.rb
+++ b/lib/line/bot/v2/shop/model/mission_sticker_request.rb
@@ -34,8 +34,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/account_link_event.rb
+++ b/lib/line/bot/v2/webhook/model/account_link_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :link
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "accountLink"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @link = link
+            @link = link.is_a?(Line::Bot::V2::Webhook::LinkContent) ? link : Line::Bot::V2::Webhook::LinkContent.create(**link)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/action_result.rb
+++ b/lib/line/bot/v2/webhook/model/action_result.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/activated_event.rb
+++ b/lib/line/bot/v2/webhook/model/activated_event.rb
@@ -24,7 +24,6 @@ module Line
           attr_accessor :chat_control
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -35,17 +34,28 @@ module Line
           )
             @type = "activated"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
-            @chat_control = chat_control
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
+            @chat_control = chat_control.is_a?(Line::Bot::V2::Webhook::ChatControl) ? chat_control : Line::Bot::V2::Webhook::ChatControl.create(**chat_control)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/all_mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/all_mentionee.rb
@@ -20,7 +20,6 @@ module Line
           attr_accessor :length # The length of the text of the mentioned user. For a mention @example, 8 is the length.
 
           def initialize(
-            type:,
             index:,
             length:,
             **dynamic_attributes
@@ -32,8 +31,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/attached_module_content.rb
+++ b/lib/line/bot/v2/webhook/model/attached_module_content.rb
@@ -19,7 +19,6 @@ module Line
           attr_accessor :scopes # An array of strings indicating the scope permitted by the admin of the LINE Official Account.
 
           def initialize(
-            type:,
             bot_id:,
             scopes:,
             **dynamic_attributes
@@ -27,12 +26,29 @@ module Line
             @type = "attached"
             
             @bot_id = bot_id
-            @scopes = scopes
+            @scopes = scopes.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Webhook::string.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/audio_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/audio_message_content.rb
@@ -20,7 +20,6 @@ module Line
           attr_accessor :duration # Length of audio file (milliseconds)
 
           def initialize(
-            type:,
             id:,
             content_provider:,
             duration: nil,
@@ -29,13 +28,24 @@ module Line
             @type = "audio"
             
             @id = id
-            @content_provider = content_provider
+            @content_provider = content_provider.is_a?(Line::Bot::V2::Webhook::ContentProvider) ? content_provider : Line::Bot::V2::Webhook::ContentProvider.create(**content_provider)
             @duration = duration
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/beacon_content.rb
+++ b/lib/line/bot/v2/webhook/model/beacon_content.rb
@@ -29,8 +29,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/bot_resumed_event.rb
+++ b/lib/line/bot/v2/webhook/model/bot_resumed_event.rb
@@ -23,7 +23,6 @@ module Line
           attr_accessor :delivery_context
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -33,16 +32,27 @@ module Line
           )
             @type = "botResumed"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/bot_suspended_event.rb
+++ b/lib/line/bot/v2/webhook/model/bot_suspended_event.rb
@@ -23,7 +23,6 @@ module Line
           attr_accessor :delivery_context
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -33,16 +32,27 @@ module Line
           )
             @type = "botSuspended"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/callback_request.rb
+++ b/lib/line/bot/v2/webhook/model/callback_request.rb
@@ -24,12 +24,29 @@ module Line
           )
             
             @destination = destination
-            @events = events
+            @events = events.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Webhook::Event.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/chat_control.rb
+++ b/lib/line/bot/v2/webhook/model/chat_control.rb
@@ -23,8 +23,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/content_provider.rb
+++ b/lib/line/bot/v2/webhook/model/content_provider.rb
@@ -30,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/deactivated_event.rb
+++ b/lib/line/bot/v2/webhook/model/deactivated_event.rb
@@ -23,7 +23,6 @@ module Line
           attr_accessor :delivery_context
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -33,16 +32,27 @@ module Line
           )
             @type = "deactivated"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/delivery_context.rb
+++ b/lib/line/bot/v2/webhook/model/delivery_context.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/detached_module_content.rb
+++ b/lib/line/bot/v2/webhook/model/detached_module_content.rb
@@ -19,7 +19,6 @@ module Line
           attr_accessor :reason # Reason for detaching
 
           def initialize(
-            type:,
             bot_id:,
             reason:,
             **dynamic_attributes
@@ -31,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/emoji.rb
+++ b/lib/line/bot/v2/webhook/model/emoji.rb
@@ -32,8 +32,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/event_mode.rb
+++ b/lib/line/bot/v2/webhook/model/event_mode.rb
@@ -21,8 +21,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/file_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/file_message_content.rb
@@ -20,7 +20,6 @@ module Line
           attr_accessor :file_size # File size in bytes
 
           def initialize(
-            type:,
             id:,
             file_name:,
             file_size:,
@@ -34,8 +33,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/follow_detail.rb
+++ b/lib/line/bot/v2/webhook/model/follow_detail.rb
@@ -23,8 +23,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/follow_event.rb
+++ b/lib/line/bot/v2/webhook/model/follow_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :follow
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "follow"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @follow = follow
+            @follow = follow.is_a?(Line::Bot::V2::Webhook::FollowDetail) ? follow : Line::Bot::V2::Webhook::FollowDetail.create(**follow)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/group_source.rb
+++ b/lib/line/bot/v2/webhook/model/group_source.rb
@@ -19,7 +19,6 @@ module Line
           attr_accessor :user_id # ID of the source user. Only included in message events. Only users of LINE for iOS and LINE for Android are included in userId.
 
           def initialize(
-            type:,
             group_id:,
             user_id: nil,
             **dynamic_attributes
@@ -31,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/image_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/image_message_content.rb
@@ -21,7 +21,6 @@ module Line
           attr_accessor :quote_token # Quote token to quote this message. 
 
           def initialize(
-            type:,
             id:,
             content_provider:,
             image_set: nil,
@@ -31,14 +30,25 @@ module Line
             @type = "image"
             
             @id = id
-            @content_provider = content_provider
-            @image_set = image_set
+            @content_provider = content_provider.is_a?(Line::Bot::V2::Webhook::ContentProvider) ? content_provider : Line::Bot::V2::Webhook::ContentProvider.create(**content_provider)
+            @image_set = image_set.is_a?(Line::Bot::V2::Webhook::ImageSet) || image_set.nil? ? image_set : Line::Bot::V2::Webhook::ImageSet.create(**image_set)
             @quote_token = quote_token
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/image_set.rb
+++ b/lib/line/bot/v2/webhook/model/image_set.rb
@@ -29,8 +29,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/join_event.rb
+++ b/lib/line/bot/v2/webhook/model/join_event.rb
@@ -24,7 +24,6 @@ module Line
           attr_accessor :reply_token # Reply token used to send reply message to this event
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -35,17 +34,28 @@ module Line
           )
             @type = "join"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/joined_members.rb
+++ b/lib/line/bot/v2/webhook/model/joined_members.rb
@@ -19,12 +19,29 @@ module Line
             **dynamic_attributes
           )
             
-            @members = members
+            @members = members.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Webhook::UserSource.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/joined_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/joined_membership_content.rb
@@ -18,7 +18,6 @@ module Line
           attr_accessor :membership_id # The ID of the membership that the user joined. This is defined for each membership.
 
           def initialize(
-            type:,
             membership_id:,
             **dynamic_attributes
           )
@@ -28,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/leave_event.rb
+++ b/lib/line/bot/v2/webhook/model/leave_event.rb
@@ -23,7 +23,6 @@ module Line
           attr_accessor :delivery_context
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -33,16 +32,27 @@ module Line
           )
             @type = "leave"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/left_members.rb
+++ b/lib/line/bot/v2/webhook/model/left_members.rb
@@ -19,12 +19,29 @@ module Line
             **dynamic_attributes
           )
             
-            @members = members
+            @members = members.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Webhook::UserSource.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/left_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/left_membership_content.rb
@@ -18,7 +18,6 @@ module Line
           attr_accessor :membership_id # The ID of the membership that the user left. This is defined for each membership.
 
           def initialize(
-            type:,
             membership_id:,
             **dynamic_attributes
           )
@@ -28,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/link_content.rb
+++ b/lib/line/bot/v2/webhook/model/link_content.rb
@@ -27,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/link_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/link_things_content.rb
@@ -18,7 +18,6 @@ module Line
           attr_accessor :device_id # Device ID of the device that has been linked with LINE.
 
           def initialize(
-            type:,
             device_id:,
             **dynamic_attributes
           )
@@ -28,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/location_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/location_message_content.rb
@@ -22,7 +22,6 @@ module Line
           attr_accessor :longitude # Longitude
 
           def initialize(
-            type:,
             id:,
             title: nil,
             address: nil,
@@ -40,8 +39,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/member_joined_event.rb
+++ b/lib/line/bot/v2/webhook/model/member_joined_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :joined
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "memberJoined"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @joined = joined
+            @joined = joined.is_a?(Line::Bot::V2::Webhook::JoinedMembers) ? joined : Line::Bot::V2::Webhook::JoinedMembers.create(**joined)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/member_left_event.rb
+++ b/lib/line/bot/v2/webhook/model/member_left_event.rb
@@ -24,7 +24,6 @@ module Line
           attr_accessor :left
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -35,17 +34,28 @@ module Line
           )
             @type = "memberLeft"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
-            @left = left
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
+            @left = left.is_a?(Line::Bot::V2::Webhook::LeftMembers) ? left : Line::Bot::V2::Webhook::LeftMembers.create(**left)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/membership_content.rb
@@ -24,8 +24,32 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              joined: Line::Bot::V2::Webhook::JoinedMembershipContent,
+              left: Line::Bot::V2::Webhook::LeftMembershipContent,
+              renewed: Line::Bot::V2::Webhook::RenewedMembershipContent,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/membership_event.rb
+++ b/lib/line/bot/v2/webhook/model/membership_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :membership
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "membership"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @membership = membership
+            @membership = membership.is_a?(Line::Bot::V2::Webhook::MembershipContent) ? membership : Line::Bot::V2::Webhook::MembershipContent.create(**membership)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/mention.rb
+++ b/lib/line/bot/v2/webhook/model/mention.rb
@@ -19,12 +19,29 @@ module Line
             **dynamic_attributes
           )
             
-            @mentionees = mentionees
+            @mentionees = mentionees.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Webhook::Mentionee.create(**item)
+              else
+                item
+              end
+            end
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/mentionee.rb
@@ -30,8 +30,31 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              all: Line::Bot::V2::Webhook::AllMentionee,
+              user: Line::Bot::V2::Webhook::UserMentionee,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/message_event.rb
+++ b/lib/line/bot/v2/webhook/model/message_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :message
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "message"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @message = message
+            @message = message.is_a?(Line::Bot::V2::Webhook::MessageContent) ? message : Line::Bot::V2::Webhook::MessageContent.create(**message)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/module_content.rb
+++ b/lib/line/bot/v2/webhook/model/module_content.rb
@@ -23,8 +23,31 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              attached: Line::Bot::V2::Webhook::AttachedModuleContent,
+              detached: Line::Bot::V2::Webhook::DetachedModuleContent,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/module_event.rb
+++ b/lib/line/bot/v2/webhook/model/module_event.rb
@@ -24,7 +24,6 @@ module Line
           attr_accessor :_module
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -35,17 +34,28 @@ module Line
           )
             @type = "module"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
-            @_module = _module
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
+            @_module = _module.is_a?(Line::Bot::V2::Webhook::ModuleContent) ? _module : Line::Bot::V2::Webhook::ModuleContent.create(**_module)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/pnp_delivery.rb
+++ b/lib/line/bot/v2/webhook/model/pnp_delivery.rb
@@ -24,8 +24,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/pnp_delivery_completion_event.rb
+++ b/lib/line/bot/v2/webhook/model/pnp_delivery_completion_event.rb
@@ -24,7 +24,6 @@ module Line
           attr_accessor :delivery
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -35,17 +34,28 @@ module Line
           )
             @type = "delivery"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
-            @delivery = delivery
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
+            @delivery = delivery.is_a?(Line::Bot::V2::Webhook::PnpDelivery) ? delivery : Line::Bot::V2::Webhook::PnpDelivery.create(**delivery)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/postback_content.rb
+++ b/lib/line/bot/v2/webhook/model/postback_content.rb
@@ -26,8 +26,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/postback_event.rb
+++ b/lib/line/bot/v2/webhook/model/postback_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :postback
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "postback"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @postback = postback
+            @postback = postback.is_a?(Line::Bot::V2::Webhook::PostbackContent) ? postback : Line::Bot::V2::Webhook::PostbackContent.create(**postback)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/renewed_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/renewed_membership_content.rb
@@ -18,7 +18,6 @@ module Line
           attr_accessor :membership_id # The ID of the membership that the user renewed. This is defined for each membership.
 
           def initialize(
-            type:,
             membership_id:,
             **dynamic_attributes
           )
@@ -28,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/room_source.rb
+++ b/lib/line/bot/v2/webhook/model/room_source.rb
@@ -19,7 +19,6 @@ module Line
           attr_accessor :room_id # Room ID of the source multi-person chat
 
           def initialize(
-            type:,
             user_id: nil,
             room_id:,
             **dynamic_attributes
@@ -31,8 +30,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/scenario_result.rb
+++ b/lib/line/bot/v2/webhook/model/scenario_result.rb
@@ -39,14 +39,31 @@ module Line
             @start_time = start_time
             @end_time = end_time
             @result_code = result_code
-            @action_results = action_results
+            @action_results = action_results&.map do |item|
+              if item.is_a?(Hash)
+                Line::Bot::V2::Webhook::ActionResult.create(**item)
+              else
+                item
+              end
+            end
             @ble_notification_payload = ble_notification_payload
             @error_reason = error_reason
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/scenario_result_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/scenario_result_things_content.rb
@@ -19,7 +19,6 @@ module Line
           attr_accessor :result
 
           def initialize(
-            type:,
             device_id:,
             result:,
             **dynamic_attributes
@@ -27,12 +26,23 @@ module Line
             @type = "scenarioResult"
             
             @device_id = device_id
-            @result = result
+            @result = result.is_a?(Line::Bot::V2::Webhook::ScenarioResult) ? result : Line::Bot::V2::Webhook::ScenarioResult.create(**result)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/source.rb
+++ b/lib/line/bot/v2/webhook/model/source.rb
@@ -25,8 +25,32 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              group: Line::Bot::V2::Webhook::GroupSource,
+              room: Line::Bot::V2::Webhook::RoomSource,
+              user: Line::Bot::V2::Webhook::UserSource,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/things_content.rb
+++ b/lib/line/bot/v2/webhook/model/things_content.rb
@@ -23,8 +23,32 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            klass = detect_class(args[:type])
+            return klass.new(**args) if klass
+            
+            return new(**args)
+          end
+
+          private
+
+          def self.detect_class(type)
+            {
+              link: Line::Bot::V2::Webhook::LinkThingsContent,
+              scenarioResult: Line::Bot::V2::Webhook::ScenarioResultThingsContent,
+              unlink: Line::Bot::V2::Webhook::UnlinkThingsContent,
+            }[type.to_sym]
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/things_event.rb
+++ b/lib/line/bot/v2/webhook/model/things_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :things
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "things"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @things = things
+            @things = things.is_a?(Line::Bot::V2::Webhook::ThingsContent) ? things : Line::Bot::V2::Webhook::ThingsContent.create(**things)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unfollow_event.rb
+++ b/lib/line/bot/v2/webhook/model/unfollow_event.rb
@@ -23,7 +23,6 @@ module Line
           attr_accessor :delivery_context
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -33,16 +32,27 @@ module Line
           )
             @type = "unfollow"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unlink_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/unlink_things_content.rb
@@ -18,7 +18,6 @@ module Line
           attr_accessor :device_id # Device ID of the device that has been linked with LINE.
 
           def initialize(
-            type:,
             device_id:,
             **dynamic_attributes
           )
@@ -28,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unsend_detail.rb
+++ b/lib/line/bot/v2/webhook/model/unsend_detail.rb
@@ -23,8 +23,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/unsend_event.rb
+++ b/lib/line/bot/v2/webhook/model/unsend_event.rb
@@ -24,7 +24,6 @@ module Line
           attr_accessor :unsend
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -35,17 +34,28 @@ module Line
           )
             @type = "unsend"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
-            @unsend = unsend
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
+            @unsend = unsend.is_a?(Line::Bot::V2::Webhook::UnsendDetail) ? unsend : Line::Bot::V2::Webhook::UnsendDetail.create(**unsend)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/user_mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/user_mentionee.rb
@@ -22,7 +22,6 @@ module Line
           attr_accessor :is_self # Whether the mentioned user is the bot that receives the webhook.
 
           def initialize(
-            type:,
             index:,
             length:,
             user_id: nil,
@@ -38,8 +37,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/user_source.rb
+++ b/lib/line/bot/v2/webhook/model/user_source.rb
@@ -18,7 +18,6 @@ module Line
           attr_accessor :user_id # ID of the source user
 
           def initialize(
-            type:,
             user_id: nil,
             **dynamic_attributes
           )
@@ -28,8 +27,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/video_play_complete.rb
+++ b/lib/line/bot/v2/webhook/model/video_play_complete.rb
@@ -23,8 +23,19 @@ module Line
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook/model/video_play_complete_event.rb
+++ b/lib/line/bot/v2/webhook/model/video_play_complete_event.rb
@@ -25,7 +25,6 @@ module Line
           attr_accessor :video_play_complete
 
           def initialize(
-            type:,
             source: nil,
             timestamp:,
             mode:,
@@ -37,18 +36,29 @@ module Line
           )
             @type = "videoPlayComplete"
             
-            @source = source
+            @source = source.is_a?(Line::Bot::V2::Webhook::Source) || source.nil? ? source : Line::Bot::V2::Webhook::Source.create(**source)
             @timestamp = timestamp
             @mode = mode
             @webhook_event_id = webhook_event_id
-            @delivery_context = delivery_context
+            @delivery_context = delivery_context.is_a?(Line::Bot::V2::Webhook::DeliveryContext) ? delivery_context : Line::Bot::V2::Webhook::DeliveryContext.create(**delivery_context)
             @reply_token = reply_token
-            @video_play_complete = video_play_complete
+            @video_play_complete = video_play_complete.is_a?(Line::Bot::V2::Webhook::VideoPlayComplete) ? video_play_complete : Line::Bot::V2::Webhook::VideoPlayComplete.create(**video_play_complete)
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key
-              instance_variable_set("@#{key}", value)
+
+              if value.is_a?(Hash)
+                struct_klass = Struct.new(*value.keys.map(&:to_sym))
+                struct_values = value.map { |_k, v| v.is_a?(Hash) ? Line::Bot::V2::Utils.hash_to_struct(v) : v }
+                instance_variable_set("@#{key}", struct_klass.new(*struct_values))
+              else
+                instance_variable_set("@#{key}", value)
+              end
             end
+          end
+
+          def self.create(args)
+            return new(**args)
           end
         end
       end

--- a/lib/line/bot/v2/webhook_parser.rb
+++ b/lib/line/bot/v2/webhook_parser.rb
@@ -21,11 +21,11 @@ module Line
         #   The unmodified request body (exactly as received).
         # @param signature [String]
         #   The value of the 'X-LINE-Signature' header.
-        # @return [Array<Line::Bot::V2::Webhook::Event, Struct>]
+        # @return [Array<Line::Bot::V2::Webhook::Event>]
         #   An array of event objects. Recognized events become instances of classes
-        #   under `Line::Bot::V2::Webhook::*Event`; otherwise, they're returned as `Struct`.
-        #   `Struct` is returned as fallback only when the event class is not defined in line-bot-sdk library.
-        #   When you update the SDK, you may not need to handle `Struct` anymore.
+        #   under `Line::Bot::V2::Webhook::*Event`;
+        #   `Line::Bot::V2::Webhook::Event` is returned as fallback only when the event class is not defined in line-bot-sdk library.
+        #   When you update the SDK, you may not need to handle `Line::Bot::V2::Webhook::Event` anymore.
         # @raise [InvalidSignatureError]
         #   If the signature fails verification.
         #

--- a/lib/line/bot/v2/webhook_parser.rb
+++ b/lib/line/bot/v2/webhook_parser.rb
@@ -58,19 +58,11 @@ module Line
 
           data = JSON.parse(body.chomp, symbolize_names: true)
           data = Line::Bot::V2::Utils.deep_underscore(data)
+          data = Line::Bot::V2::Utils.deep_convert_reserved_words(data)
+          data = Line::Bot::V2::Utils.deep_symbolize(data)
 
           data[:events].map do |event|
-            event_class_name = determine_class_name(:events, event)
-            event_class = begin
-              Object.const_get(event_class_name)
-            rescue StandardError
-              nil
-            end
-
-            # If there is no specific webhook class, leave the value as is
-            event_instance = event_class ? create_instance(event_class, event) : event
-
-            deep_hash_to_struct(event_instance)
+            Line::Bot::V2::Webhook::Event.create(**event)
           end
         end
 
@@ -95,133 +87,6 @@ module Line
           res = 0
           b.each_byte { |byte| res |= byte ^ l.shift }
           res == 0
-        end
-
-        def create_instance(klass, attributes)
-          keyword_args = {}
-
-          attributes.each do |key, value|
-            if value.is_a?(Hash)
-              nested_class_name = determine_class_name(key, value)
-              if nested_class_name
-                nested_klass = Object.const_get(nested_class_name)
-                value = create_instance(nested_klass, value)
-              end
-            elsif value.is_a?(Array)
-              value = value.map do |item|
-                nested_class_name = determine_class_name(key, item)
-                if nested_class_name
-                  nested_klass = Object.const_get(nested_class_name)
-                  create_instance(nested_klass, item)
-                else
-                  item
-                end
-              end
-            end
-
-            # CodeGen add _ prefix to reserved words
-            # see: https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractRubyCodegen.java
-            if Line::Bot::V2::RESERVED_WORDS.include?(key)
-              keyword_args["_#{key}".to_sym] = value
-            else
-              keyword_args[key] = value
-            end
-          end
-
-          begin
-            klass.new(**keyword_args)
-          rescue ArgumentError => e
-            attributes # Return the original hash if unknown keyword error occurs
-          end
-        end
-
-        # TODO: Derive classes from rbs information or define attribute/class mappings for each class and derive classes from them.
-        def determine_class_name(key, value)
-          class_name = if key == :events && value.is_a?(Hash) && value[:type] == 'delivery'
-                         'PnpDeliveryCompletionEvent'
-                       elsif key == :message && value.is_a?(Hash) && value[:type]
-                         pascalize(value[:type]) + 'MessageContent'
-                       elsif key == :mentionees && value.is_a?(Hash) && value[:type]
-                         pascalize(value[:type]) + 'Mentionee'
-                       elsif key == :module && value.is_a?(Hash) && value[:type]
-                         pascalize(value[:type]) + 'ModuleContent'
-                       elsif key == :things && value.is_a?(Hash) && value[:type]
-                         pascalize(value[:type]) + 'ThingsContent'
-                       elsif value.is_a?(Hash) && value[:type] && ['user', 'group', 'room'].include?(value[:type])
-                         pascalize(value[:type]) + 'Source'
-                       elsif key == :result && value.is_a?(Hash) && value[:result_code]
-                         'ScenarioResult'
-                       elsif key == :content_provider # This has type, but there is no typed ContentProvider
-                         'ContentProvider'
-                       elsif key == :_module # This has type, but there is no typed ModuleContent
-                         'ModuleContent'
-                       elsif key == :unsend
-                         'UnsendDetail'
-                       elsif key == :follow
-                         'FollowDetail'
-                       elsif key == :joined
-                         'JoinedMembers'
-                       elsif key == :left
-                         'LeftMembers'
-                       elsif key == :postback
-                         'PostbackContent'
-                       elsif key == :beacon
-                         'BeaconContent'
-                       elsif key == :link
-                         'LinkContent'
-                       elsif key == :delivery
-                         'PnpDelivery'
-                       elsif value.is_a?(Hash) && value[:type] # Event etc.
-                         pascalize(value[:type]) + singularize(pascalize(key))
-                       elsif value.is_a?(Array) && key.to_s.end_with?('s')
-                         pascalize(singularize(key))
-                       else
-                         singularize(pascalize(key))
-                       end
-
-          full_class_name = "Line::Bot::V2::Webhook::#{class_name}"
-          Object.const_defined?(full_class_name) ? full_class_name : nil
-        end
-
-        def pascalize(str)
-          str.to_s.gsub(/(?:^|_)([a-z])/) { ::Regexp.last_match(1).upcase }
-        end
-
-        def singularize(str)
-          str = str.to_s
-
-          if str.end_with?('ies')
-            str.sub(/ies$/, 'y')
-          elsif str.end_with?('ves')
-            str.sub(/ves$/, 'f')
-          elsif str.end_with?('oes') || str.end_with?('xes') || str.end_with?('ses')
-            str.sub(/es$/, '')
-          elsif str.end_with?('s')
-            str.sub(/s$/, '')
-          else
-            str
-          end
-        end
-
-        def deep_hash_to_struct(obj)
-          case obj
-          when Hash
-            keys = obj.keys.map(&:to_sym)
-            struct_class = Struct.new(*keys)
-            struct_class.new(*obj.values.map { |value| deep_hash_to_struct(value) })
-          when Array
-            obj.map { |item| deep_hash_to_struct(item) }
-          else
-            if obj.respond_to?(:instance_variables)
-              obj.instance_variables.each do |var|
-                value = obj.instance_variable_get(var)
-                if value.is_a?(Hash) || value.is_a?(Array) || value.respond_to?(:instance_variables)
-                  obj.instance_variable_set(var, deep_hash_to_struct(value))
-                end
-              end
-            end
-            obj
-          end
         end
       end
     end

--- a/sig/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rbs
+++ b/sig/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             kids: Array[String]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ChannelAccessTokenKeyIdsResponse
         end
       end
     end

--- a/sig/line/bot/v2/channel_access_token/model/error_response.rbs
+++ b/sig/line/bot/v2/channel_access_token/model/error_response.rbs
@@ -20,6 +20,8 @@ module Line
             error: String?,
             error_description: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorResponse
         end
       end
     end

--- a/sig/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rbs
+++ b/sig/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rbs
@@ -25,6 +25,8 @@ module Line
             token_type: String,
             key_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> IssueChannelAccessTokenResponse
         end
       end
     end

--- a/sig/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rbs
+++ b/sig/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rbs
@@ -23,6 +23,8 @@ module Line
             expires_in: Integer,
             token_type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> IssueShortLivedChannelAccessTokenResponse
         end
       end
     end

--- a/sig/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rbs
+++ b/sig/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rbs
@@ -23,6 +23,8 @@ module Line
             expires_in: Integer,
             token_type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> IssueStatelessChannelAccessTokenResponse
         end
       end
     end

--- a/sig/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rbs
+++ b/sig/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rbs
@@ -22,6 +22,8 @@ module Line
             expires_in: Integer,
             scope: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> VerifyChannelAccessTokenResponse
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/age_tile.rbs
+++ b/sig/line/bot/v2/insight/model/age_tile.rbs
@@ -19,6 +19,8 @@ module Line
             age: 'from0to14'|'from15to19'|'from20to24'|'from25to29'|'from30to34'|'from35to39'|'from40to44'|'from45to49'|'from50'|'from50to54'|'from55to59'|'from60to64'|'from65to69'|'from70'|'unknown'?,
             percentage: Float?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AgeTile
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/app_type_tile.rbs
+++ b/sig/line/bot/v2/insight/model/app_type_tile.rbs
@@ -19,6 +19,8 @@ module Line
             app_type: 'ios'|'android'|'others'?,
             percentage: Float?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AppTypeTile
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/area_tile.rbs
+++ b/sig/line/bot/v2/insight/model/area_tile.rbs
@@ -19,6 +19,8 @@ module Line
             area: String?,
             percentage: Float?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AreaTile
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/error_detail.rbs
+++ b/sig/line/bot/v2/insight/model/error_detail.rbs
@@ -19,6 +19,8 @@ module Line
             message: String?,
             property: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorDetail
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/error_response.rbs
+++ b/sig/line/bot/v2/insight/model/error_response.rbs
@@ -20,6 +20,8 @@ module Line
             message: String,
             details: Array[ErrorDetail]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorResponse
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/gender_tile.rbs
+++ b/sig/line/bot/v2/insight/model/gender_tile.rbs
@@ -19,6 +19,8 @@ module Line
             gender: 'male'|'female'|'unknown'?,
             percentage: Float?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GenderTile
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_friends_demographics_response.rbs
+++ b/sig/line/bot/v2/insight/model/get_friends_demographics_response.rbs
@@ -29,6 +29,8 @@ module Line
             app_types: Array[AppTypeTile]?,
             subscription_periods: Array[SubscriptionPeriodTile]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetFriendsDemographicsResponse
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_message_event_response.rbs
+++ b/sig/line/bot/v2/insight/model/get_message_event_response.rbs
@@ -23,6 +23,8 @@ module Line
             messages: Array[GetMessageEventResponseMessage]?,
             clicks: Array[GetMessageEventResponseClick]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetMessageEventResponse
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_message_event_response_click.rbs
+++ b/sig/line/bot/v2/insight/model/get_message_event_response_click.rbs
@@ -25,6 +25,8 @@ module Line
             unique_click: Integer?,
             unique_click_of_request: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetMessageEventResponseClick
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_message_event_response_message.rbs
+++ b/sig/line/bot/v2/insight/model/get_message_event_response_message.rbs
@@ -39,6 +39,8 @@ module Line
             unique_media_played75_percent: Integer?,
             unique_media_played100_percent: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetMessageEventResponseMessage
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_message_event_response_overview.rbs
+++ b/sig/line/bot/v2/insight/model/get_message_event_response_overview.rbs
@@ -30,6 +30,8 @@ module Line
             unique_media_played: Integer?,
             unique_media_played100_percent: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetMessageEventResponseOverview
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_number_of_followers_response.rbs
+++ b/sig/line/bot/v2/insight/model/get_number_of_followers_response.rbs
@@ -25,6 +25,8 @@ module Line
             targeted_reaches: Integer?,
             blocks: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetNumberOfFollowersResponse
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rbs
+++ b/sig/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rbs
@@ -39,6 +39,8 @@ module Line
             api_narrowcast: Integer?,
             api_reply: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetNumberOfMessageDeliveriesResponse
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_statistics_per_unit_response.rbs
+++ b/sig/line/bot/v2/insight/model/get_statistics_per_unit_response.rbs
@@ -23,6 +23,8 @@ module Line
             messages: Array[GetStatisticsPerUnitResponseMessage],
             clicks: Array[GetStatisticsPerUnitResponseClick]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetStatisticsPerUnitResponse
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rbs
+++ b/sig/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rbs
@@ -26,6 +26,8 @@ module Line
             unique_click: Integer?,
             unique_click_of_request: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetStatisticsPerUnitResponseClick
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rbs
+++ b/sig/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rbs
@@ -42,6 +42,8 @@ module Line
             unique_media_played75_percent: Integer?,
             unique_media_played100_percent: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetStatisticsPerUnitResponseMessage
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rbs
+++ b/sig/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rbs
@@ -25,6 +25,8 @@ module Line
             unique_media_played: Integer?,
             unique_media_played100_percent: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetStatisticsPerUnitResponseOverview
         end
       end
     end

--- a/sig/line/bot/v2/insight/model/subscription_period_tile.rbs
+++ b/sig/line/bot/v2/insight/model/subscription_period_tile.rbs
@@ -19,6 +19,8 @@ module Line
             subscription_period: 'within7days'|'within30days'|'within90days'|'within180days'|'within365days'|'over365days'|'unknown'?,
             percentage: Float?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> SubscriptionPeriodTile
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/add_liff_app_request.rbs
+++ b/sig/line/bot/v2/liff/model/add_liff_app_request.rbs
@@ -28,6 +28,8 @@ module Line
             scope: Array['openid'|'email'|'profile'|'chat_message.write']?,
             bot_prompt: 'normal'|'aggressive'|'none'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AddLiffAppRequest
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/add_liff_app_response.rbs
+++ b/sig/line/bot/v2/liff/model/add_liff_app_response.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             liff_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AddLiffAppResponse
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/get_all_liff_apps_response.rbs
+++ b/sig/line/bot/v2/liff/model/get_all_liff_apps_response.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             apps: Array[LiffApp]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetAllLiffAppsResponse
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/liff_app.rbs
+++ b/sig/line/bot/v2/liff/model/liff_app.rbs
@@ -29,6 +29,8 @@ module Line
             scope: Array['openid'|'email'|'profile'|'chat_message.write']?,
             bot_prompt: 'normal'|'aggressive'|'none'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LiffApp
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/liff_features.rbs
+++ b/sig/line/bot/v2/liff/model/liff_features.rbs
@@ -19,6 +19,8 @@ module Line
             ble: bool?,
             qr_code: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LiffFeatures
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/liff_view.rbs
+++ b/sig/line/bot/v2/liff/model/liff_view.rbs
@@ -22,6 +22,8 @@ module Line
             url: String,
             module_mode: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LiffView
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/update_liff_app_request.rbs
+++ b/sig/line/bot/v2/liff/model/update_liff_app_request.rbs
@@ -28,6 +28,8 @@ module Line
             scope: Array['openid'|'email'|'profile'|'chat_message.write']?,
             bot_prompt: 'normal'|'aggressive'|'none'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UpdateLiffAppRequest
         end
       end
     end

--- a/sig/line/bot/v2/liff/model/update_liff_view.rbs
+++ b/sig/line/bot/v2/liff/model/update_liff_view.rbs
@@ -22,6 +22,8 @@ module Line
             url: String?,
             module_mode: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UpdateLiffView
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/adaccount.rbs
+++ b/sig/line/bot/v2/manage_audience/model/adaccount.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             name: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Adaccount
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rbs
+++ b/sig/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rbs
@@ -23,6 +23,8 @@ module Line
             upload_description: String?,
             audiences: Array[Audience]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AddAudienceToAudienceGroupRequest
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/audience.rbs
+++ b/sig/line/bot/v2/manage_audience/model/audience.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Audience
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/audience_group.rbs
+++ b/sig/line/bot/v2/manage_audience/model/audience_group.rbs
@@ -40,6 +40,8 @@ module Line
             permission: 'READ'|'READ_WRITE'?,
             create_route: 'OA_MANAGER'|'MESSAGING_API'|'POINT_AD'|'AD_MANAGER'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AudienceGroup
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/audience_group_job.rbs
+++ b/sig/line/bot/v2/manage_audience/model/audience_group_job.rbs
@@ -33,6 +33,8 @@ module Line
             audience_count: Integer?,
             created: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AudienceGroupJob
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/create_audience_group_request.rbs
+++ b/sig/line/bot/v2/manage_audience/model/create_audience_group_request.rbs
@@ -25,6 +25,8 @@ module Line
             upload_description: String?,
             audiences: Array[Audience]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CreateAudienceGroupRequest
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/create_audience_group_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/create_audience_group_response.rbs
@@ -33,6 +33,8 @@ module Line
             expire_timestamp: Float?,
             is_ifa_audience: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CreateAudienceGroupResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rbs
+++ b/sig/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rbs
@@ -23,6 +23,8 @@ module Line
             request_id: String?,
             click_url: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CreateClickBasedAudienceGroupRequest
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rbs
@@ -37,6 +37,8 @@ module Line
             expire_timestamp: Integer?,
             is_ifa_audience: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CreateClickBasedAudienceGroupResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rbs
+++ b/sig/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rbs
@@ -21,6 +21,8 @@ module Line
             description: String?,
             request_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CreateImpBasedAudienceGroupRequest
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rbs
@@ -27,6 +27,8 @@ module Line
             created: Integer?,
             request_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CreateImpBasedAudienceGroupResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/detailed_owner.rbs
+++ b/sig/line/bot/v2/manage_audience/model/detailed_owner.rbs
@@ -22,6 +22,8 @@ module Line
             id: String?,
             name: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> DetailedOwner
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/error_detail.rbs
+++ b/sig/line/bot/v2/manage_audience/model/error_detail.rbs
@@ -19,6 +19,8 @@ module Line
             message: String?,
             property: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorDetail
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/error_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/error_response.rbs
@@ -20,6 +20,8 @@ module Line
             message: String,
             details: Array[ErrorDetail]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/get_audience_data_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/get_audience_data_response.rbs
@@ -23,6 +23,8 @@ module Line
             jobs: Array[AudienceGroupJob]?,
             adaccount: Adaccount?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetAudienceDataResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/get_audience_group_authority_level_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/get_audience_group_authority_level_response.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             authority_level: 'PUBLIC'|'PRIVATE'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetAudienceGroupAuthorityLevelResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/get_audience_groups_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/get_audience_groups_response.rbs
@@ -29,6 +29,8 @@ module Line
             page: Integer?,
             size: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetAudienceGroupsResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rbs
@@ -23,6 +23,8 @@ module Line
             jobs: Array[AudienceGroupJob]?,
             owner: DetailedOwner?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetSharedAudienceDataResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/get_shared_audience_groups_response.rbs
+++ b/sig/line/bot/v2/manage_audience/model/get_shared_audience_groups_response.rbs
@@ -29,6 +29,8 @@ module Line
             page: Integer?,
             size: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetSharedAudienceGroupsResponse
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/update_audience_group_authority_level_request.rbs
+++ b/sig/line/bot/v2/manage_audience/model/update_audience_group_authority_level_request.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             authority_level: 'PUBLIC'|'PRIVATE'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UpdateAudienceGroupAuthorityLevelRequest
         end
       end
     end

--- a/sig/line/bot/v2/manage_audience/model/update_audience_group_description_request.rbs
+++ b/sig/line/bot/v2/manage_audience/model/update_audience_group_description_request.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             description: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UpdateAudienceGroupDescriptionRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/action.rbs
@@ -21,6 +21,12 @@ module Line
             type: String?,
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Action
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/age_demographic_filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/age_demographic_filter.rbs
@@ -20,6 +20,8 @@ module Line
             gte: 'age_15'|'age_20'|'age_25'|'age_30'|'age_35'|'age_40'|'age_45'|'age_50'|'age_55'|'age_60'|'age_65'|'age_70'?,
             lt: 'age_15'|'age_20'|'age_25'|'age_30'|'age_35'|'age_40'|'age_45'|'age_50'|'age_55'|'age_60'|'age_65'|'age_70'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AgeDemographicFilter
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/all_mention_target.rbs
+++ b/sig/line/bot/v2/messaging_api/model/all_mention_target.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AllMentionTarget
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/alt_uri.rbs
+++ b/sig/line/bot/v2/messaging_api/model/alt_uri.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             desktop: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AltUri
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/app_type_demographic_filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/app_type_demographic_filter.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             one_of: Array['ios'|'android']?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AppTypeDemographicFilter
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/area_demographic_filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/area_demographic_filter.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             one_of: Array['jp_01'|'jp_02'|'jp_03'|'jp_04'|'jp_05'|'jp_06'|'jp_07'|'jp_08'|'jp_09'|'jp_10'|'jp_11'|'jp_12'|'jp_13'|'jp_14'|'jp_15'|'jp_16'|'jp_17'|'jp_18'|'jp_19'|'jp_20'|'jp_21'|'jp_22'|'jp_23'|'jp_24'|'jp_25'|'jp_26'|'jp_27'|'jp_28'|'jp_29'|'jp_30'|'jp_31'|'jp_32'|'jp_33'|'jp_34'|'jp_35'|'jp_36'|'jp_37'|'jp_38'|'jp_39'|'jp_40'|'jp_41'|'jp_42'|'jp_43'|'jp_44'|'jp_45'|'jp_46'|'jp_47'|'tw_01'|'tw_02'|'tw_03'|'tw_04'|'tw_05'|'tw_06'|'tw_07'|'tw_08'|'tw_09'|'tw_10'|'tw_11'|'tw_12'|'tw_13'|'tw_14'|'tw_15'|'tw_16'|'tw_17'|'tw_18'|'tw_19'|'tw_20'|'tw_21'|'tw_22'|'th_01'|'th_02'|'th_03'|'th_04'|'th_05'|'th_06'|'th_07'|'th_08'|'id_01'|'id_02'|'id_03'|'id_04'|'id_05'|'id_06'|'id_07'|'id_08'|'id_09'|'id_10'|'id_11'|'id_12']?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AreaDemographicFilter
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/audience_recipient.rbs
+++ b/sig/line/bot/v2/messaging_api/model/audience_recipient.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             audience_group_id: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AudienceRecipient
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/audio_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/audio_message.rbs
@@ -25,6 +25,8 @@ module Line
             original_content_url: String,
             duration: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AudioMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/bot_info_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/bot_info_response.rbs
@@ -30,6 +30,8 @@ module Line
             chat_mode: 'chat'|'bot',
             mark_as_read_mode: 'auto'|'manual'
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> BotInfoResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/broadcast_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/broadcast_request.rbs
@@ -20,6 +20,8 @@ module Line
             messages: Array[Message],
             notification_disabled: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> BroadcastRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/buttons_template.rbs
+++ b/sig/line/bot/v2/messaging_api/model/buttons_template.rbs
@@ -32,6 +32,8 @@ module Line
             default_action: Action?,
             actions: Array[Action]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ButtonsTemplate
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/camera_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/camera_action.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CameraAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/camera_roll_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/camera_roll_action.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CameraRollAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/carousel_column.rbs
+++ b/sig/line/bot/v2/messaging_api/model/carousel_column.rbs
@@ -28,6 +28,8 @@ module Line
             default_action: Action?,
             actions: Array[Action]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CarouselColumn
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/carousel_template.rbs
+++ b/sig/line/bot/v2/messaging_api/model/carousel_template.rbs
@@ -22,6 +22,8 @@ module Line
             image_aspect_ratio: String?,
             image_size: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CarouselTemplate
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/chat_reference.rbs
+++ b/sig/line/bot/v2/messaging_api/model/chat_reference.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             user_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ChatReference
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/clipboard_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/clipboard_action.rbs
@@ -21,6 +21,8 @@ module Line
             label: String?,
             clipboard_text: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ClipboardAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rbs
@@ -23,6 +23,8 @@ module Line
             clipboard_text: String,
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ClipboardImagemapAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/confirm_template.rbs
+++ b/sig/line/bot/v2/messaging_api/model/confirm_template.rbs
@@ -20,6 +20,8 @@ module Line
             text: String,
             actions: Array[Action]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ConfirmTemplate
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rbs
@@ -20,6 +20,8 @@ module Line
             rich_menu_alias_id: String,
             rich_menu_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CreateRichMenuAliasRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/datetime_picker_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/datetime_picker_action.rbs
@@ -29,6 +29,8 @@ module Line
             max: String?,
             min: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> DatetimePickerAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/demographic_filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/demographic_filter.rbs
@@ -18,6 +18,12 @@ module Line
           def initialize: (
             type: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> DemographicFilter
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/emoji.rbs
+++ b/sig/line/bot/v2/messaging_api/model/emoji.rbs
@@ -21,6 +21,8 @@ module Line
             product_id: String?,
             emoji_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Emoji
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/emoji_substitution_object.rbs
+++ b/sig/line/bot/v2/messaging_api/model/emoji_substitution_object.rbs
@@ -22,6 +22,8 @@ module Line
             product_id: String,
             emoji_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> EmojiSubstitutionObject
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/error_detail.rbs
+++ b/sig/line/bot/v2/messaging_api/model/error_detail.rbs
@@ -19,6 +19,8 @@ module Line
             message: String?,
             property: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorDetail
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/error_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/error_response.rbs
@@ -22,6 +22,8 @@ module Line
             details: Array[ErrorDetail]?,
             sent_messages: Array[SentMessage]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/filter.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             demographic: DemographicFilter?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Filter
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_block_style.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_block_style.rbs
@@ -21,6 +21,8 @@ module Line
             separator: bool?,
             separator_color: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexBlockStyle
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_box.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_box.rbs
@@ -70,6 +70,8 @@ module Line
             align_items: 'center'|'flex-start'|'flex-end'?,
             background: FlexBoxBackground?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexBox
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_box_background.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_box_background.rbs
@@ -17,6 +17,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexBoxBackground
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rbs
@@ -26,6 +26,8 @@ module Line
             center_color: String?,
             center_position: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexBoxLinearGradient
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_bubble.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_bubble.rbs
@@ -32,6 +32,8 @@ module Line
             size: 'nano'|'micro'|'deca'|'hecto'|'kilo'|'mega'|'giga'?,
             action: Action?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexBubble
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_bubble_styles.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_bubble_styles.rbs
@@ -23,6 +23,8 @@ module Line
             body: FlexBlockStyle?,
             footer: FlexBlockStyle?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexBubbleStyles
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_button.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_button.rbs
@@ -44,6 +44,8 @@ module Line
             adjust_mode: 'shrink-to-fit'?,
             scaling: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexButton
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_carousel.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_carousel.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             contents: Array[FlexBubble]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexCarousel
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_component.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_component.rbs
@@ -17,6 +17,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexComponent
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_container.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_container.rbs
@@ -17,6 +17,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexContainer
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_filler.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_filler.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             flex: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexFiller
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_icon.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_icon.rbs
@@ -37,6 +37,8 @@ module Line
             offset_end: String?,
             scaling: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexIcon
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_image.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_image.rbs
@@ -49,6 +49,8 @@ module Line
             action: Action?,
             animated: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexImage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_message.rbs
@@ -25,6 +25,8 @@ module Line
             alt_text: String,
             contents: FlexContainer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_separator.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_separator.rbs
@@ -20,6 +20,8 @@ module Line
             margin: String?,
             color: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexSeparator
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_span.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_span.rbs
@@ -28,6 +28,8 @@ module Line
             style: 'normal'|'italic'?,
             decoration: 'none'|'underline'|'line-through'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexSpan
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_text.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_text.rbs
@@ -60,6 +60,8 @@ module Line
             adjust_mode: 'shrink-to-fit'?,
             scaling: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexText
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/flex_video.rbs
+++ b/sig/line/bot/v2/messaging_api/model/flex_video.rbs
@@ -26,6 +26,8 @@ module Line
             aspect_ratio: String?,
             action: Action?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FlexVideo
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/gender_demographic_filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/gender_demographic_filter.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             one_of: Array['male'|'female']?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GenderDemographicFilter
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rbs
@@ -20,6 +20,8 @@ module Line
             custom_aggregation_units: Array[String],
             _next: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetAggregationUnitNameListResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             num_of_custom_aggregation_units: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetAggregationUnitUsageResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/get_followers_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/get_followers_response.rbs
@@ -20,6 +20,8 @@ module Line
             user_ids: Array[String],
             _next: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetFollowersResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rbs
@@ -21,6 +21,8 @@ module Line
             user_ids: Array[String],
             _next: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetJoinedMembershipUsersResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/get_membership_subscription_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/get_membership_subscription_response.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             subscriptions: Array[Subscription]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetMembershipSubscriptionResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             status: 'processing'|'succeeded'|'failed'
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetMessageContentTranscodingResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rbs
@@ -20,6 +20,8 @@ module Line
             endpoint: String,
             active: bool
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetWebhookEndpointResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/group_member_count_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/group_member_count_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             count: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GroupMemberCountResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/group_summary_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/group_summary_response.rbs
@@ -22,6 +22,8 @@ module Line
             group_name: String,
             picture_url: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GroupSummaryResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/group_user_profile_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/group_user_profile_response.rbs
@@ -22,6 +22,8 @@ module Line
             user_id: String,
             picture_url: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GroupUserProfileResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/image_carousel_column.rbs
+++ b/sig/line/bot/v2/messaging_api/model/image_carousel_column.rbs
@@ -19,6 +19,8 @@ module Line
             image_url: String,
             action: Action
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImageCarouselColumn
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/image_carousel_template.rbs
+++ b/sig/line/bot/v2/messaging_api/model/image_carousel_template.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             columns: Array[ImageCarouselColumn]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImageCarouselTemplate
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/image_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/image_message.rbs
@@ -25,6 +25,8 @@ module Line
             original_content_url: String,
             preview_image_url: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImageMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/imagemap_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/imagemap_action.rbs
@@ -20,6 +20,12 @@ module Line
             type: String,
             area: ImagemapArea
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImagemapAction
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/imagemap_area.rbs
+++ b/sig/line/bot/v2/messaging_api/model/imagemap_area.rbs
@@ -23,6 +23,8 @@ module Line
             width: Integer,
             height: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImagemapArea
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/imagemap_base_size.rbs
+++ b/sig/line/bot/v2/messaging_api/model/imagemap_base_size.rbs
@@ -19,6 +19,8 @@ module Line
             height: Integer,
             width: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImagemapBaseSize
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/imagemap_external_link.rbs
+++ b/sig/line/bot/v2/messaging_api/model/imagemap_external_link.rbs
@@ -19,6 +19,8 @@ module Line
             link_uri: String?,
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImagemapExternalLink
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/imagemap_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/imagemap_message.rbs
@@ -31,6 +31,8 @@ module Line
             actions: Array[ImagemapAction],
             video: ImagemapVideo?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImagemapMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/imagemap_video.rbs
+++ b/sig/line/bot/v2/messaging_api/model/imagemap_video.rbs
@@ -23,6 +23,8 @@ module Line
             area: ImagemapArea?,
             external_link: ImagemapExternalLink?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImagemapVideo
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/issue_link_token_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/issue_link_token_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             link_token: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> IssueLinkTokenResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/limit.rbs
+++ b/sig/line/bot/v2/messaging_api/model/limit.rbs
@@ -21,6 +21,8 @@ module Line
             max: Integer?,
             up_to_remaining_quota: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Limit
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/location_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/location_action.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LocationAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/location_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/location_message.rbs
@@ -29,6 +29,8 @@ module Line
             latitude: Float,
             longitude: Float
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LocationMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             chat: ChatReference
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MarkMessagesAsReadRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/members_ids_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/members_ids_response.rbs
@@ -19,6 +19,8 @@ module Line
             member_ids: Array[String],
             _next: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MembersIdsResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/membership.rbs
+++ b/sig/line/bot/v2/messaging_api/model/membership.rbs
@@ -35,6 +35,8 @@ module Line
             is_in_app_purchase: bool,
             is_published: bool
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Membership
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/membership_list_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/membership_list_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             memberships: Array[Membership]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MembershipListResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/mention_substitution_object.rbs
+++ b/sig/line/bot/v2/messaging_api/model/mention_substitution_object.rbs
@@ -20,6 +20,8 @@ module Line
           def initialize: (
             mentionee: MentionTarget
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MentionSubstitutionObject
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/mention_target.rbs
+++ b/sig/line/bot/v2/messaging_api/model/mention_target.rbs
@@ -17,6 +17,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MentionTarget
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/message.rbs
@@ -22,6 +22,12 @@ module Line
             quick_reply: QuickReply?,
             sender: Sender?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Message
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/message_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/message_action.rbs
@@ -20,6 +20,8 @@ module Line
             label: String?,
             text: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MessageAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/message_imagemap_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/message_imagemap_action.rbs
@@ -22,6 +22,8 @@ module Line
             text: String,
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MessageImagemapAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/message_quota_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/message_quota_response.rbs
@@ -20,6 +20,8 @@ module Line
             type: 'none'|'limited',
             value: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MessageQuotaResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/multicast_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/multicast_request.rbs
@@ -24,6 +24,8 @@ module Line
             notification_disabled: bool?,
             custom_aggregation_units: Array[String]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MulticastRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/narrowcast_progress_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/narrowcast_progress_response.rbs
@@ -32,6 +32,8 @@ module Line
             accepted_time: String,
             completed_time: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> NarrowcastProgressResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/narrowcast_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/narrowcast_request.rbs
@@ -26,6 +26,8 @@ module Line
             limit: Limit?,
             notification_disabled: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> NarrowcastRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/number_of_messages_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/number_of_messages_response.rbs
@@ -19,6 +19,8 @@ module Line
             status: 'ready'|'unready'|'unavailable_for_privacy'|'out_of_service',
             success: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> NumberOfMessagesResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/operator_demographic_filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/operator_demographic_filter.rbs
@@ -22,6 +22,8 @@ module Line
             _or: Array[DemographicFilter]?,
             _not: DemographicFilter?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> OperatorDemographicFilter
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/operator_recipient.rbs
+++ b/sig/line/bot/v2/messaging_api/model/operator_recipient.rbs
@@ -22,6 +22,8 @@ module Line
             _or: Array[Recipient]?,
             _not: Recipient?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> OperatorRecipient
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/pnp_messages_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/pnp_messages_request.rbs
@@ -22,6 +22,8 @@ module Line
             to: String,
             notification_disabled: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PnpMessagesRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/postback_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/postback_action.rbs
@@ -28,6 +28,8 @@ module Line
             input_option: 'closeRichMenu'|'openRichMenu'|'openKeyboard'|'openVoice'?,
             fill_in_text: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PostbackAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/push_message_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/push_message_request.rbs
@@ -24,6 +24,8 @@ module Line
             notification_disabled: bool?,
             custom_aggregation_units: Array[String]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PushMessageRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/push_message_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/push_message_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             sent_messages: Array[SentMessage]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PushMessageResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/quick_reply.rbs
+++ b/sig/line/bot/v2/messaging_api/model/quick_reply.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             items: Array[QuickReplyItem]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> QuickReply
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/quick_reply_item.rbs
+++ b/sig/line/bot/v2/messaging_api/model/quick_reply_item.rbs
@@ -22,6 +22,8 @@ module Line
             action: Action?,
             type: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> QuickReplyItem
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/quota_consumption_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/quota_consumption_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             total_usage: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> QuotaConsumptionResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/recipient.rbs
+++ b/sig/line/bot/v2/messaging_api/model/recipient.rbs
@@ -18,6 +18,12 @@ module Line
           def initialize: (
             type: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Recipient
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/redelivery_recipient.rbs
+++ b/sig/line/bot/v2/messaging_api/model/redelivery_recipient.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             request_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RedeliveryRecipient
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/reply_message_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/reply_message_request.rbs
@@ -22,6 +22,8 @@ module Line
             messages: Array[Message],
             notification_disabled: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ReplyMessageRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/reply_message_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/reply_message_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             sent_messages: Array[SentMessage]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ReplyMessageResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             aliases: Array[RichMenuAliasResponse]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuAliasListResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_alias_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_alias_response.rbs
@@ -19,6 +19,8 @@ module Line
             rich_menu_alias_id: String,
             rich_menu_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuAliasResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_area.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_area.rbs
@@ -20,6 +20,8 @@ module Line
             bounds: RichMenuBounds?,
             action: Action?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuArea
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rbs
@@ -21,6 +21,8 @@ module Line
             from: String,
             to: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBatchLinkOperation
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rbs
@@ -19,6 +19,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBatchOperation
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rbs
@@ -22,6 +22,8 @@ module Line
             accepted_time: String,
             completed_time: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBatchProgressResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_batch_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_batch_request.rbs
@@ -19,6 +19,8 @@ module Line
             operations: Array[RichMenuBatchOperation],
             resume_request_key: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBatchRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBatchUnlinkAllOperation
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             from: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBatchUnlinkOperation
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_bounds.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_bounds.rbs
@@ -25,6 +25,8 @@ module Line
             width: Integer?,
             height: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBounds
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rbs
@@ -20,6 +20,8 @@ module Line
             rich_menu_id: String,
             user_ids: Array[String]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBulkLinkRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             user_ids: Array[String]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuBulkUnlinkRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_id_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_id_response.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             rich_menu_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuIdResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_list_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_list_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             richmenus: Array[RichMenuResponse]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuListResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_request.rbs
@@ -25,6 +25,8 @@ module Line
             chat_bar_text: String?,
             areas: Array[RichMenuArea]?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_response.rbs
@@ -27,6 +27,8 @@ module Line
             chat_bar_text: String,
             areas: Array[RichMenuArea]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_size.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_size.rbs
@@ -20,6 +20,8 @@ module Line
             width: Integer?,
             height: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuSize
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/rich_menu_switch_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/rich_menu_switch_action.rbs
@@ -22,6 +22,8 @@ module Line
             data: String?,
             rich_menu_alias_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RichMenuSwitchAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/room_member_count_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/room_member_count_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             count: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RoomMemberCountResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/room_user_profile_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/room_user_profile_response.rbs
@@ -22,6 +22,8 @@ module Line
             user_id: String,
             picture_url: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RoomUserProfileResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/sender.rbs
+++ b/sig/line/bot/v2/messaging_api/model/sender.rbs
@@ -20,6 +20,8 @@ module Line
             name: String?,
             icon_url: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Sender
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/sent_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/sent_message.rbs
@@ -19,6 +19,8 @@ module Line
             id: String,
             quote_token: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> SentMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             endpoint: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> SetWebhookEndpointRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/show_loading_animation_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/show_loading_animation_request.rbs
@@ -20,6 +20,8 @@ module Line
             chat_id: String,
             loading_seconds: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ShowLoadingAnimationRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/sticker_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/sticker_message.rbs
@@ -27,6 +27,8 @@ module Line
             sticker_id: String,
             quote_token: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> StickerMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/subscribed_membership_plan.rbs
+++ b/sig/line/bot/v2/messaging_api/model/subscribed_membership_plan.rbs
@@ -28,6 +28,8 @@ module Line
             price: Float,
             currency: 'JPY'|'TWD'|'THB'
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> SubscribedMembershipPlan
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/subscribed_membership_user.rbs
+++ b/sig/line/bot/v2/messaging_api/model/subscribed_membership_user.rbs
@@ -24,6 +24,8 @@ module Line
             next_billing_date: String,
             total_subscription_months: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> SubscribedMembershipUser
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/subscription.rbs
+++ b/sig/line/bot/v2/messaging_api/model/subscription.rbs
@@ -20,6 +20,8 @@ module Line
             membership: SubscribedMembershipPlan,
             user: SubscribedMembershipUser
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Subscription
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rbs
+++ b/sig/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rbs
@@ -20,6 +20,8 @@ module Line
             gte: 'day_7'|'day_30'|'day_90'|'day_180'|'day_365'?,
             lt: 'day_7'|'day_30'|'day_90'|'day_180'|'day_365'?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> SubscriptionPeriodDemographicFilter
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/substitution_object.rbs
+++ b/sig/line/bot/v2/messaging_api/model/substitution_object.rbs
@@ -18,6 +18,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> SubstitutionObject
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/template.rbs
+++ b/sig/line/bot/v2/messaging_api/model/template.rbs
@@ -17,6 +17,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Template
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/template_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/template_message.rbs
@@ -25,6 +25,8 @@ module Line
             alt_text: String,
             template: Template
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> TemplateMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             endpoint: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> TestWebhookEndpointRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rbs
@@ -26,6 +26,8 @@ module Line
             reason: String,
             detail: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> TestWebhookEndpointResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/text_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/text_message.rbs
@@ -27,6 +27,8 @@ module Line
             emojis: Array[Emoji]?,
             quote_token: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> TextMessage
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/text_message_v2.rbs
+++ b/sig/line/bot/v2/messaging_api/model/text_message_v2.rbs
@@ -27,6 +27,8 @@ module Line
             substitution: Object?,
             quote_token: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> TextMessageV2
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             rich_menu_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UpdateRichMenuAliasRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/uri_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/uri_action.rbs
@@ -22,6 +22,8 @@ module Line
             uri: String?,
             alt_uri: AltUri?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> URIAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/uri_imagemap_action.rbs
+++ b/sig/line/bot/v2/messaging_api/model/uri_imagemap_action.rbs
@@ -22,6 +22,8 @@ module Line
             link_uri: String,
             label: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> URIImagemapAction
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/user_mention_target.rbs
+++ b/sig/line/bot/v2/messaging_api/model/user_mention_target.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             user_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UserMentionTarget
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/user_profile_response.rbs
+++ b/sig/line/bot/v2/messaging_api/model/user_profile_response.rbs
@@ -26,6 +26,8 @@ module Line
             status_message: String?,
             language: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UserProfileResponse
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/validate_message_request.rbs
+++ b/sig/line/bot/v2/messaging_api/model/validate_message_request.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             messages: Array[Message]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ValidateMessageRequest
         end
       end
     end

--- a/sig/line/bot/v2/messaging_api/model/video_message.rbs
+++ b/sig/line/bot/v2/messaging_api/model/video_message.rbs
@@ -27,6 +27,8 @@ module Line
             preview_image_url: String,
             tracking_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> VideoMessage
         end
       end
     end

--- a/sig/line/bot/v2/module/model/acquire_chat_control_request.rbs
+++ b/sig/line/bot/v2/module/model/acquire_chat_control_request.rbs
@@ -21,6 +21,8 @@ module Line
             expired: bool?,
             ttl: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AcquireChatControlRequest
         end
       end
     end

--- a/sig/line/bot/v2/module/model/detach_module_request.rbs
+++ b/sig/line/bot/v2/module/model/detach_module_request.rbs
@@ -19,6 +19,8 @@ module Line
           def initialize: (
             bot_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> DetachModuleRequest
         end
       end
     end

--- a/sig/line/bot/v2/module/model/get_modules_response.rbs
+++ b/sig/line/bot/v2/module/model/get_modules_response.rbs
@@ -21,6 +21,8 @@ module Line
             bots: Array[ModuleBot],
             _next: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GetModulesResponse
         end
       end
     end

--- a/sig/line/bot/v2/module/model/module_bot.rbs
+++ b/sig/line/bot/v2/module/model/module_bot.rbs
@@ -27,6 +27,8 @@ module Line
             display_name: String,
             picture_url: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ModuleBot
         end
       end
     end

--- a/sig/line/bot/v2/module_attach/model/attach_module_response.rbs
+++ b/sig/line/bot/v2/module_attach/model/attach_module_response.rbs
@@ -20,6 +20,8 @@ module Line
             bot_id: String,
             scopes: Array[String]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AttachModuleResponse
         end
       end
     end

--- a/sig/line/bot/v2/shop/model/error_response.rbs
+++ b/sig/line/bot/v2/shop/model/error_response.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             message: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ErrorResponse
         end
       end
     end

--- a/sig/line/bot/v2/shop/model/mission_sticker_request.rbs
+++ b/sig/line/bot/v2/shop/model/mission_sticker_request.rbs
@@ -25,6 +25,8 @@ module Line
             product_type: String,
             send_present_message: bool
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MissionStickerRequest
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/account_link_event.rbs
+++ b/sig/line/bot/v2/webhook/model/account_link_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String?,
             link: LinkContent
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AccountLinkEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/action_result.rbs
+++ b/sig/line/bot/v2/webhook/model/action_result.rbs
@@ -19,6 +19,8 @@ module Line
             type: 'void'|'binary',
             data: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ActionResult
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/activated_event.rbs
+++ b/sig/line/bot/v2/webhook/model/activated_event.rbs
@@ -30,6 +30,8 @@ module Line
             delivery_context: DeliveryContext,
             chat_control: ChatControl
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ActivatedEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/all_mentionee.rbs
+++ b/sig/line/bot/v2/webhook/model/all_mentionee.rbs
@@ -22,6 +22,8 @@ module Line
             index: Integer,
             length: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AllMentionee
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/attached_module_content.rbs
+++ b/sig/line/bot/v2/webhook/model/attached_module_content.rbs
@@ -21,6 +21,8 @@ module Line
             bot_id: String,
             scopes: Array[String]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AttachedModuleContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/audio_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/audio_message_content.rbs
@@ -23,6 +23,8 @@ module Line
             content_provider: ContentProvider,
             duration: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> AudioMessageContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/beacon_content.rbs
+++ b/sig/line/bot/v2/webhook/model/beacon_content.rbs
@@ -21,6 +21,8 @@ module Line
             type: 'enter'|'banner'|'stay',
             dm: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> BeaconContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/beacon_event.rbs
+++ b/sig/line/bot/v2/webhook/model/beacon_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String,
             beacon: BeaconContent
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> BeaconEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/bot_resumed_event.rbs
+++ b/sig/line/bot/v2/webhook/model/bot_resumed_event.rbs
@@ -28,6 +28,8 @@ module Line
             webhook_event_id: String,
             delivery_context: DeliveryContext
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> BotResumedEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/bot_suspended_event.rbs
+++ b/sig/line/bot/v2/webhook/model/bot_suspended_event.rbs
@@ -28,6 +28,8 @@ module Line
             webhook_event_id: String,
             delivery_context: DeliveryContext
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> BotSuspendedEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/callback_request.rbs
+++ b/sig/line/bot/v2/webhook/model/callback_request.rbs
@@ -21,6 +21,8 @@ module Line
             destination: String,
             events: Array[Event]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> CallbackRequest
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/chat_control.rbs
+++ b/sig/line/bot/v2/webhook/model/chat_control.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             expire_at: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ChatControl
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/content_provider.rbs
+++ b/sig/line/bot/v2/webhook/model/content_provider.rbs
@@ -22,6 +22,8 @@ module Line
             original_content_url: String?,
             preview_image_url: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ContentProvider
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/deactivated_event.rbs
+++ b/sig/line/bot/v2/webhook/model/deactivated_event.rbs
@@ -28,6 +28,8 @@ module Line
             webhook_event_id: String,
             delivery_context: DeliveryContext
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> DeactivatedEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/delivery_context.rbs
+++ b/sig/line/bot/v2/webhook/model/delivery_context.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             is_redelivery: bool
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> DeliveryContext
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/detached_module_content.rbs
+++ b/sig/line/bot/v2/webhook/model/detached_module_content.rbs
@@ -21,6 +21,8 @@ module Line
             bot_id: String,
             reason: 'bot_deleted'
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> DetachedModuleContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/emoji.rbs
+++ b/sig/line/bot/v2/webhook/model/emoji.rbs
@@ -23,6 +23,8 @@ module Line
             product_id: String,
             emoji_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Emoji
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/event.rbs
+++ b/sig/line/bot/v2/webhook/model/event.rbs
@@ -28,6 +28,12 @@ module Line
             webhook_event_id: String,
             delivery_context: DeliveryContext
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Event
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/file_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/file_message_content.rbs
@@ -23,6 +23,8 @@ module Line
             file_name: String,
             file_size: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FileMessageContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/follow_detail.rbs
+++ b/sig/line/bot/v2/webhook/model/follow_detail.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             is_unblocked: bool
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FollowDetail
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/follow_event.rbs
+++ b/sig/line/bot/v2/webhook/model/follow_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String,
             follow: FollowDetail
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> FollowEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/group_source.rbs
+++ b/sig/line/bot/v2/webhook/model/group_source.rbs
@@ -21,6 +21,8 @@ module Line
             group_id: String,
             user_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> GroupSource
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/image_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/image_message_content.rbs
@@ -25,6 +25,8 @@ module Line
             image_set: ImageSet?,
             quote_token: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImageMessageContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/image_set.rbs
+++ b/sig/line/bot/v2/webhook/model/image_set.rbs
@@ -21,6 +21,8 @@ module Line
             index: Integer?,
             total: Integer?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ImageSet
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/join_event.rbs
+++ b/sig/line/bot/v2/webhook/model/join_event.rbs
@@ -30,6 +30,8 @@ module Line
             delivery_context: DeliveryContext,
             reply_token: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> JoinEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/joined_members.rbs
+++ b/sig/line/bot/v2/webhook/model/joined_members.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             members: Array[UserSource]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> JoinedMembers
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/joined_membership_content.rbs
+++ b/sig/line/bot/v2/webhook/model/joined_membership_content.rbs
@@ -19,6 +19,8 @@ module Line
             type: String,
             membership_id: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> JoinedMembershipContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/leave_event.rbs
+++ b/sig/line/bot/v2/webhook/model/leave_event.rbs
@@ -28,6 +28,8 @@ module Line
             webhook_event_id: String,
             delivery_context: DeliveryContext
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LeaveEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/left_members.rbs
+++ b/sig/line/bot/v2/webhook/model/left_members.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             members: Array[UserSource]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LeftMembers
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/left_membership_content.rbs
+++ b/sig/line/bot/v2/webhook/model/left_membership_content.rbs
@@ -19,6 +19,8 @@ module Line
             type: String,
             membership_id: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LeftMembershipContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/link_content.rbs
+++ b/sig/line/bot/v2/webhook/model/link_content.rbs
@@ -20,6 +20,8 @@ module Line
             result: 'ok'|'failed',
             nonce: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LinkContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/link_things_content.rbs
+++ b/sig/line/bot/v2/webhook/model/link_things_content.rbs
@@ -19,6 +19,8 @@ module Line
             type: String,
             device_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LinkThingsContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/location_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/location_message_content.rbs
@@ -27,6 +27,8 @@ module Line
             latitude: Float,
             longitude: Float
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> LocationMessageContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/member_joined_event.rbs
+++ b/sig/line/bot/v2/webhook/model/member_joined_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String,
             joined: JoinedMembers
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MemberJoinedEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/member_left_event.rbs
+++ b/sig/line/bot/v2/webhook/model/member_left_event.rbs
@@ -30,6 +30,8 @@ module Line
             delivery_context: DeliveryContext,
             left: LeftMembers
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MemberLeftEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/membership_content.rbs
+++ b/sig/line/bot/v2/webhook/model/membership_content.rbs
@@ -18,6 +18,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MembershipContent
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/membership_event.rbs
+++ b/sig/line/bot/v2/webhook/model/membership_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String,
             membership: MembershipContent
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MembershipEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/mention.rbs
+++ b/sig/line/bot/v2/webhook/model/mention.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             mentionees: Array[Mentionee]
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Mention
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/mentionee.rbs
+++ b/sig/line/bot/v2/webhook/model/mentionee.rbs
@@ -22,6 +22,12 @@ module Line
             index: Integer,
             length: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Mentionee
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/message_content.rbs
@@ -20,6 +20,12 @@ module Line
             type: String,
             id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MessageContent
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/message_event.rbs
+++ b/sig/line/bot/v2/webhook/model/message_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String?,
             message: MessageContent
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> MessageEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/module_content.rbs
+++ b/sig/line/bot/v2/webhook/model/module_content.rbs
@@ -17,6 +17,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ModuleContent
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/module_event.rbs
+++ b/sig/line/bot/v2/webhook/model/module_event.rbs
@@ -30,6 +30,8 @@ module Line
             delivery_context: DeliveryContext,
             _module: ModuleContent
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ModuleEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/pnp_delivery.rbs
+++ b/sig/line/bot/v2/webhook/model/pnp_delivery.rbs
@@ -18,6 +18,8 @@ module Line
           def initialize: (
             data: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PnpDelivery
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/pnp_delivery_completion_event.rbs
+++ b/sig/line/bot/v2/webhook/model/pnp_delivery_completion_event.rbs
@@ -30,6 +30,8 @@ module Line
             delivery_context: DeliveryContext,
             delivery: PnpDelivery
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PnpDeliveryCompletionEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/postback_content.rbs
+++ b/sig/line/bot/v2/webhook/model/postback_content.rbs
@@ -19,6 +19,8 @@ module Line
             data: String,
             params: Object?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PostbackContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/postback_event.rbs
+++ b/sig/line/bot/v2/webhook/model/postback_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String?,
             postback: PostbackContent
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> PostbackEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/renewed_membership_content.rbs
+++ b/sig/line/bot/v2/webhook/model/renewed_membership_content.rbs
@@ -19,6 +19,8 @@ module Line
             type: String,
             membership_id: Integer
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RenewedMembershipContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/room_source.rbs
+++ b/sig/line/bot/v2/webhook/model/room_source.rbs
@@ -21,6 +21,8 @@ module Line
             user_id: String?,
             room_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> RoomSource
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/scenario_result.rbs
+++ b/sig/line/bot/v2/webhook/model/scenario_result.rbs
@@ -32,6 +32,8 @@ module Line
             ble_notification_payload: String?,
             error_reason: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ScenarioResult
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/scenario_result_things_content.rbs
+++ b/sig/line/bot/v2/webhook/model/scenario_result_things_content.rbs
@@ -21,6 +21,8 @@ module Line
             device_id: String,
             result: ScenarioResult
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ScenarioResultThingsContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/source.rbs
+++ b/sig/line/bot/v2/webhook/model/source.rbs
@@ -19,6 +19,12 @@ module Line
           def initialize: (
             type: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> Source
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/sticker_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/sticker_message_content.rbs
@@ -34,6 +34,8 @@ module Line
             quote_token: String,
             quoted_message_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> StickerMessageContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/text_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/text_message_content.rbs
@@ -29,6 +29,8 @@ module Line
             quote_token: String,
             quoted_message_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> TextMessageContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/things_content.rbs
+++ b/sig/line/bot/v2/webhook/model/things_content.rbs
@@ -17,6 +17,12 @@ module Line
           def initialize: (
             type: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ThingsContent
+
+          private
+
+          def self.detect_class: (type: String) -> Class
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/things_event.rbs
+++ b/sig/line/bot/v2/webhook/model/things_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String,
             things: ThingsContent
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> ThingsEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/unfollow_event.rbs
+++ b/sig/line/bot/v2/webhook/model/unfollow_event.rbs
@@ -28,6 +28,8 @@ module Line
             webhook_event_id: String,
             delivery_context: DeliveryContext
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UnfollowEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/unlink_things_content.rbs
+++ b/sig/line/bot/v2/webhook/model/unlink_things_content.rbs
@@ -19,6 +19,8 @@ module Line
             type: String,
             device_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UnlinkThingsContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/unsend_detail.rbs
+++ b/sig/line/bot/v2/webhook/model/unsend_detail.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             message_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UnsendDetail
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/unsend_event.rbs
+++ b/sig/line/bot/v2/webhook/model/unsend_event.rbs
@@ -30,6 +30,8 @@ module Line
             delivery_context: DeliveryContext,
             unsend: UnsendDetail
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UnsendEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/user_mentionee.rbs
+++ b/sig/line/bot/v2/webhook/model/user_mentionee.rbs
@@ -26,6 +26,8 @@ module Line
             user_id: String?,
             is_self: bool?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UserMentionee
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/user_source.rbs
+++ b/sig/line/bot/v2/webhook/model/user_source.rbs
@@ -19,6 +19,8 @@ module Line
             type: String,
             user_id: String?
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> UserSource
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/video_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/video_message_content.rbs
@@ -25,6 +25,8 @@ module Line
             content_provider: ContentProvider,
             quote_token: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> VideoMessageContent
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/video_play_complete.rbs
+++ b/sig/line/bot/v2/webhook/model/video_play_complete.rbs
@@ -17,6 +17,8 @@ module Line
           def initialize: (
             tracking_id: String
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> VideoPlayComplete
         end
       end
     end

--- a/sig/line/bot/v2/webhook/model/video_play_complete_event.rbs
+++ b/sig/line/bot/v2/webhook/model/video_play_complete_event.rbs
@@ -32,6 +32,8 @@ module Line
             reply_token: String,
             video_play_complete: VideoPlayComplete
           ) -> void
+
+          def self.create: (args: Hash[Symbol, untyped]) -> VideoPlayCompleteEvent
         end
       end
     end

--- a/sig/line/bot/v2/webhook_parser.rbs
+++ b/sig/line/bot/v2/webhook_parser.rbs
@@ -10,8 +10,7 @@ module Line
         def parse: (
             body: String,
             signature: String
-          ) -> Array[Webhook::Event | ::Struct[untyped]]
-
+          ) -> Array[Webhook::Event]
 
         private
 
@@ -20,16 +19,6 @@ module Line
         def secure_compare: (a: String, b: String) -> bool
 
         def verify_signature: (body: String, signature: String) -> bool
-
-        def create_instance: (untyped klass, Hash[Symbol, untyped] attributes) -> untyped
-
-        def determine_class_name: (Symbol key, untyped value) -> (String | nil)
-
-        def pascalize: (String|Symbol str) -> String
-
-        def singularize: (String|Symbol str) -> String
-
-        def deep_hash_to_struct: (untyped) -> untyped
       end
     end
   end

--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -372,9 +372,10 @@ describe 'misc' do
 
       expect(status_code).to eq(200)
       expect(body).to be_a(Line::Bot::V2::MessagingApi::PushMessageResponse)
-      # TODO: Add test after https://github.com/line/line-bot-sdk-ruby/issues/440 is resolved
-      # We should access body.sent_messages[0].id and body.sent_messages[0].quote_token, but it's not possible now.
-      expect(body.sent_messages).to eq([{ id: '461230966842064897', quote_token: 'IStG5h1Tz7b...' }])
+      expect(body.sent_messages).to be_a(Array)
+      expect(body.sent_messages[0]).to be_a(Line::Bot::V2::MessagingApi::SentMessage)
+      expect(body.sent_messages[0].id).to eq('461230966842064897')
+      expect(body.sent_messages[0].quote_token).to eq('IStG5h1Tz7b...')
     end
 
     it 'response - success - using hash (not recommended way)' do
@@ -452,9 +453,10 @@ describe 'misc' do
 
       expect(status_code).to eq(200)
       expect(body).to be_a(Line::Bot::V2::MessagingApi::PushMessageResponse)
-      # TODO: Add test after https://github.com/line/line-bot-sdk-ruby/issues/440 is resolved
-      # We should access body.sent_messages[0].id and body.sent_messages[0].quote_token, but it's not possible now.
-      expect(body.sent_messages).to eq([{ id: '461230966842064897', quote_token: 'IStG5h1Tz7b...' }])
+      expect(body.sent_messages).to be_a(Array)
+      expect(body.sent_messages[0]).to be_a(Line::Bot::V2::MessagingApi::SentMessage)
+      expect(body.sent_messages[0].id).to eq('461230966842064897')
+      expect(body.sent_messages[0].quote_token).to eq('IStG5h1Tz7b...')
     end
 
     it 'request with x_line_retry_key: nil' do
@@ -530,9 +532,10 @@ describe 'misc' do
       )
       expect(status_code).to eq(200)
       expect(body).to be_a(Line::Bot::V2::MessagingApi::PushMessageResponse)
-      # TODO: Add test after https://github.com/line/line-bot-sdk-ruby/issues/440 is resolved
-      # We should access body.sent_messages[0].id and body.sent_messages[0].quote_token, but it's not possible now.
-      expect(body.sent_messages).to eq([{ id: '461230966842064897', quote_token: 'IStG5h1Tz7b...' }])
+      expect(body.sent_messages).to be_a(Array)
+      expect(body.sent_messages[0]).to be_a(Line::Bot::V2::MessagingApi::SentMessage)
+      expect(body.sent_messages[0].id).to eq('461230966842064897')
+      expect(body.sent_messages[0].quote_token).to eq('IStG5h1Tz7b...')
     end
 
     it 'request with  x-line-retry-key header - conflicted' do
@@ -588,9 +591,10 @@ describe 'misc' do
       expect(status_code).to eq(409)
       expect(body).to be_a(Line::Bot::V2::MessagingApi::ErrorResponse)
       expect(body.message).to eq("The retry key is already accepted")
-      # TODO: Add test after https://github.com/line/line-bot-sdk-ruby/issues/440 is resolved.
-      # We should access body.sent_messages[0].id and body.sent_messages[0].quote_token, but it's not possible now.
-      expect(body.sent_messages).to eq([{ id: '461230966842064897', quote_token: 'IStG5h1Tz7b...' }])
+      expect(body.sent_messages).to be_a(Array)
+      expect(body.sent_messages[0]).to be_a(Line::Bot::V2::MessagingApi::SentMessage)
+      expect(body.sent_messages[0].id).to eq('461230966842064897')
+      expect(body.sent_messages[0].quote_token).to eq('IStG5h1Tz7b...')
       expect(headers['x-line-request-id']).to eq(request_id)
       expect(headers['x-line-accepted-request-id']).to eq(accepted_request_id)
     end
@@ -975,10 +979,14 @@ describe 'misc' do
         alt_text: 'Test Alt Text',
         contents: Line::Bot::V2::MessagingApi::FlexBubble.new( # FlexBubble has many optional fields
           direction: 'ltr',
-          body: Line::Bot::V2::MessagingApi::FlexText.new(
-            text: 'Test Text',
-            weight: 'bold',
-            size: 'xl'
+          body: Line::Bot::V2::MessagingApi::FlexBox.new(
+            layout: 'vertical',
+            contents: [
+              Line::Bot::V2::MessagingApi::FlexText.new(
+                text: 'Test Text',
+                weight: 'bold'
+              )
+            ]
           )
         ),
         quick_reply: Line::Bot::V2::MessagingApi::QuickReply.new(
@@ -995,10 +1003,15 @@ describe 'misc' do
               type: 'bubble',
               direction: 'ltr',
               body: {
-                type: 'text',
-                text: 'Test Text',
-                size: 'xl',
-                weight: 'bold'
+                type: 'box',
+                layout: 'vertical',
+                contents: [
+                  {
+                    type: 'text',
+                    text: 'Test Text',
+                    weight: 'bold'
+                  }
+                ]
               }
             }
           }

--- a/spec/line/bot/v2/webhook_parser_spec.rb
+++ b/spec/line/bot/v2/webhook_parser_spec.rb
@@ -23,7 +23,10 @@ describe Line::Bot::V2::WebhookParser do
                 "foo": {
                   "bar": "baz"
                 },
-                "mode": "active"
+                "mode": "active",
+                "deliveryContext": {
+                  "isRedelivery": false
+                }
               }
             ]
           }
@@ -35,13 +38,15 @@ describe Line::Bot::V2::WebhookParser do
         expect(events).not_to be_empty
 
         event = events.first
-        expect(event).to be_a(Struct)
+        expect(event).to be_a(Line::Bot::V2::Webhook::Event)
         expect(event.type).to eq('hoge')
         expect(event.webhook_event_id).to eq('01G17EJCGAVV66J5WNA7ZCTF6H')
         expect(event.timestamp).to eq(1650591346705)
         expect(event.foo).to be_a(Struct)
         expect(event.foo.bar).to eq('baz')
         expect(event.mode).to eq('active')
+        expect(event.delivery_context).to be_a(Line::Bot::V2::Webhook::DeliveryContext)
+        expect(event.delivery_context.is_redelivery).to be false
       end
     end
 
@@ -94,7 +99,7 @@ describe Line::Bot::V2::WebhookParser do
         expect(event.webhook_event_id).to eq('01FZ74A0TDDPYRVKNK77XKC3ZR')
         expect(event.delivery_context).to be_a(Line::Bot::V2::Webhook::DeliveryContext)
         expect(event.delivery_context.is_redelivery).to be false
-        expect(event.message).to be_a(Struct)
+        expect(event.message).to be_a(Line::Bot::V2::Webhook::MessageContent)
         expect(event.message.id).to eq('444573844083572737')
         expect(event.message.type).to eq('hoge')
         expect(event.message.quote_token).to eq('q3Plxr4AgKd...')
@@ -1212,8 +1217,8 @@ describe Line::Bot::V2::WebhookParser do
         expect(event.delivery_context.is_redelivery).to be false
         expect(event.postback).to be_a(Line::Bot::V2::Webhook::PostbackContent)
         expect(event.postback.data).to eq('storeId=12345')
-        expect(event.postback.params).to be_a(Struct)
-        expect(event.postback.params.datetime).to eq('2017-12-25T01:00')
+        expect(event.postback.params).to be_a(Hash)
+        expect(event.postback.params[:datetime]).to eq('2017-12-25T01:00')
       end
     end
 
@@ -1266,9 +1271,9 @@ describe Line::Bot::V2::WebhookParser do
         expect(event.delivery_context.is_redelivery).to be false
         expect(event.postback).to be_a(Line::Bot::V2::Webhook::PostbackContent)
         expect(event.postback.data).to eq('richmenu-changed-to-b')
-        expect(event.postback.params).to be_a(Struct)
-        expect(event.postback.params.new_rich_menu_alias_id).to eq('richmenu-alias-b')
-        expect(event.postback.params.status).to eq('SUCCESS')
+        expect(event.postback.params).to be_a(Hash)
+        expect(event.postback.params[:new_rich_menu_alias_id]).to eq('richmenu-alias-b')
+        expect(event.postback.params[:status]).to eq('SUCCESS')
       end
     end
 

--- a/spec/line/bot/v2/webhook_parser_spec.rb
+++ b/spec/line/bot/v2/webhook_parser_spec.rb
@@ -1853,5 +1853,56 @@ describe Line::Bot::V2::WebhookParser do
         expect(event.things.result.action_results[2].type).to eq('void')
       end
     end
+
+    context 'with a MembershioEvent' do
+      let(:webhook) do
+        <<~JSON
+          {
+            "destination": "xxxxxxxxxx",
+            "events": [
+              {
+                "type": "membership",
+                "source": {
+                  "type": "user",
+                  "userId": "U4af4980629..."
+                },
+                "replyToken": "nHuyWiB7yP5Zw52FIkcQobQuGDXCTA",
+                "membership": {
+                  "type": "joined",
+                  "membershipId": 3189
+                },
+                "timestamp": 1462629479859,
+                "mode": "active",
+                "webhookEventId": "01FZ74A0TDDPYRVKNK77XKC3ZR",
+                "deliveryContext": {
+                  "isRedelivery": false
+                }
+              }
+            ]
+          }
+        JSON
+      end
+
+      it 'parses the webhook as a MembershipEvent' do
+        events = parser.parse(webhook, signature)
+        expect(events).not_to be_empty
+
+        event = events.first
+        expect(event).to be_a(Line::Bot::V2::Webhook::MembershipEvent)
+        expect(event.type).to eq('membership')
+        expect(event.source).to be_a(Line::Bot::V2::Webhook::UserSource)
+        expect(event.source.type).to eq('user')
+        expect(event.source.user_id).to eq('U4af4980629...')
+        expect(event.reply_token).to eq('nHuyWiB7yP5Zw52FIkcQobQuGDXCTA')
+        expect(event.membership).to be_a(Line::Bot::V2::Webhook::MembershipContent)
+        expect(event.membership.type).to eq('joined')
+        expect(event.membership.membership_id).to eq(3189)
+        expect(event.timestamp).to eq(1462629479859)
+        expect(event.mode).to eq('active')
+        expect(event.webhook_event_id).to eq('01FZ74A0TDDPYRVKNK77XKC3ZR')
+        expect(event.delivery_context).to be_a(Line::Bot::V2::Webhook::DeliveryContext)
+        expect(event.delivery_context.is_redelivery).to be false
+      end
+    end
   end
 end


### PR DESCRIPTION
When classes are nested, child classes were not initialized.
This caused the following problems
- Need to write webhook parser by hand with detailed conditionals https://github.com/line/line-bot-sdk-ruby/issues/404
- Responses could not be parsed correctly https://github.com/line/line-bot-sdk-ruby/issues/440

This PR resolves those problems.
This also adds support for `MembershipEvent`, which was not supported by the webhook parser. 61c4a5a3697816aa58fe1cd7c6d3ad1381147c29