### PR TITLE
Add test for audiencegroup list API

### DIFF
--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -1031,4 +1031,61 @@ describe 'misc' do
       client.broadcast_with_http_info(broadcast_request: Line::Bot::V2::MessagingApi::BroadcastRequest.new(messages: [flex_message]))
     end
   end
+
+  describe 'GET /v2/bot/audienceGroup/list' do
+    let(:client) { Line::Bot::V2::ManageAudience::ApiClient.new(channel_access_token: 'test-channel-access-token') }
+    let(:response_body) do
+      { "audienceGroups" => [
+          {
+            "audienceGroupId" => 1234567890123,
+            "createRoute" => "OA_MANAGER",
+            "type": "CLICK",
+            "description": "audienceGroup Name",
+            "status": "IN_PROGRESS",
+            "audienceCount": 8619,
+            "created": 1611114828,
+            "permission": "READ",
+            "isIfaAudience": false,
+            "expireTimestamp": 1626753228,
+            "requestId": "c10c3d86-f565-...",
+            "clickUrl": "https://example.com/"
+          },
+          {
+            "audienceGroupId": 2345678901234,
+            "createRoute": "AD_MANAGER",
+            "type": "APP_EVENT",
+            "description": "audienceGroup Name",
+            "status": "READY",
+            "audienceCount": 3368,
+            "created": 1608619802,
+            "permission": "READ",
+            "activated": 1610068515,
+            "inactiveTimestamp": 1625620516,
+            "isIfaAudience": false
+          }
+        ],
+        "hasNextPage": false,
+        "totalCount": 2,
+        "readWriteAudienceGroupTotalCount": 0,
+        "size": 40,
+        "page": 1}.to_json
+    end
+    let(:response_code) { 200 }
+
+    it 'query parameter is encoded' do
+      stub_request(:get, "https://api.line.me/v2/bot/audienceGroup/list?size=40&page=1&description=audienceGroup%20Name")
+        .with(
+          headers: {
+            'Authorization' => "Bearer test-channel-access-token"
+          }
+        )
+        .to_return(status: response_code, body: response_body, headers: { 'Content-Type' => 'application/json' })
+
+      body, status_code, headers = client.get_audience_groups_with_http_info(page: 1, size: 40, description: 'audienceGroup Name')
+
+      expect(status_code).to eq(200)
+      expect(body.audience_groups.size).to eq(2)
+      expect(body.audience_groups[0].description).to eq('audienceGroup Name')
+    end
+  end
 end


### PR DESCRIPTION
- many query parameters with whitespace
- nested response (https://github.com/line/line-bot-sdk-ruby/pull/461 resolved this)