### PR TITLE
Add test to check content type header

### DIFF
--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -70,10 +70,10 @@ describe 'misc' do
             .with(
               headers: {
                 'Authorization' => "Bearer #{channel_access_token}",
-                'Content-Type' => 'image/jpeg' # webmock doesn't support specific image content types so we use regex
+                'Content-Type' => 'image/jpeg'
               }
             )
-            .to_return(status: 200, body: 'Success', headers: { 'Content-Type' => 'application/json' })
+            .to_return(status: 200, body: '{}', headers: { 'Content-Type' => 'application/json' })
 
           response_body, status_code, headers = client.set_rich_menu_image_with_http_info(
             rich_menu_id: rich_menu_id,
@@ -81,6 +81,9 @@ describe 'misc' do
           )
 
           expect(status_code).to eq(200)
+          expect(response_body).to eq("{}")
+          expect(headers['Content-Type']).to eq(nil)
+          expect(headers['content-type']).to eq('application/json')
         end
       end
     end
@@ -109,6 +112,7 @@ describe 'misc' do
 
         expect(status_code).to eq(200)
         expect(body.status).to eq('ready')
+        expect(headers['content-type']).to eq('application/json')
       end
     end
 
@@ -128,6 +132,7 @@ describe 'misc' do
 
         expect(status_code).to eq(200)
         expect(body).to eq('binary data')
+        expect(headers['content-type']).to eq('image/jpeg')
       end
     end
   end


### PR DESCRIPTION
This change adds tests for the headers for scenario about downloading.

The behavior where all header names become lowercase when converting the response header object to a hash likely depends on `Net::HTTP`.

Some libraries including `Net::HTTP` convert uppercase access to lowercase(In ruby, String#downcase.to_s), but once it's converted to a hash in bot-sdk-ruby, they don't do this.
However, since HTTP header names are not supposed to be case-sensitive (regardless of the programming language), I think this behavior is acceptable.