### PR TITLE
Add test using special fixed value for 'type' parameter

### DIFF
--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -1012,6 +1012,265 @@ describe 'misc' do
     end
   end
 
+  describe 'Line::Bot::V2::MessagingApi::DatetimePickerAction#initialize' do
+    let(:client) { Line::Bot::V2::MessagingApi::ApiClient.new(channel_access_token: 'test-channel-access-token') }
+
+    it 'creates DatetimePickerAction with minimal required fields and broadcasts correctly' do
+      text_message = Line::Bot::V2::MessagingApi::TextMessage.new(
+        text: "Please pick a date/time!",
+        quick_reply: Line::Bot::V2::MessagingApi::QuickReply.new(
+          items: [
+            Line::Bot::V2::MessagingApi::QuickReplyItem.new(
+              action: Line::Bot::V2::MessagingApi::DatetimePickerAction.new(
+                data: 'some_data',
+                mode: 'datetime',
+                label: 'Pick'
+              )
+            )
+          ]
+        )
+      )
+
+      expected_body = {
+        messages: [
+          {
+            type: 'text',
+            text: "Please pick a date/time!",
+            quickReply: {
+              items: [
+                {
+                  type: 'action',
+                  action: {
+                    type: 'datetimepicker', # important: this is the fixed type
+                    data: 'some_data',
+                    mode: 'datetime',
+                    label: 'Pick'
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        notificationDisabled: false
+      }
+
+      stub_request(:post, "https://api.line.me/v2/bot/message/broadcast")
+        .with(
+          headers: {
+            'Authorization' => "Bearer test-channel-access-token"
+          },
+          body: hash_including(expected_body)
+        )
+        .to_return(status: 200, body: "{}", headers: { 'Content-Type' => 'application/json' })
+
+      client.broadcast_with_http_info(
+        broadcast_request: Line::Bot::V2::MessagingApi::BroadcastRequest.new(messages: [text_message])
+      )
+    end
+  end
+
+  describe 'Line::Bot::V2::MessagingApi::RichMenuSwitchAction#initialize' do
+    let(:client) { Line::Bot::V2::MessagingApi::ApiClient.new(channel_access_token: 'test-channel-access-token') }
+
+    it 'creates RichMenuSwitchAction with minimal required fields and broadcasts correctly' do
+      flex_message = Line::Bot::V2::MessagingApi::FlexMessage.new(
+        alt_text: "Switch RichMenu",
+        contents: Line::Bot::V2::MessagingApi::FlexBubble.new(
+          body: Line::Bot::V2::MessagingApi::FlexBox.new(
+            layout: 'vertical',
+            contents: [
+              Line::Bot::V2::MessagingApi::FlexButton.new(
+                action: Line::Bot::V2::MessagingApi::RichMenuSwitchAction.new(
+                  data: 'switch_richmenu',
+                  rich_menu_alias_id: 'alias_xxx',
+                  label: 'Switch Menu'
+                )
+              )
+            ]
+          )
+        )
+      )
+
+      expected_body = {
+        messages: [
+          {
+            type: 'flex',
+            altText: 'Switch RichMenu',
+            contents: {
+              type: 'bubble',
+              body: {
+                type: 'box',
+                layout: 'vertical',
+                contents: [
+                  {
+                    type: 'button',
+                    action: {
+                      type: 'richmenuswitch', # important: this is the fixed type
+                      data: 'switch_richmenu',
+                      richMenuAliasId: 'alias_xxx',
+                      label: 'Switch Menu'
+                    }
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        notificationDisabled: false
+      }
+
+      stub_request(:post, "https://api.line.me/v2/bot/message/broadcast")
+        .with(
+          headers: {
+            'Authorization' => "Bearer test-channel-access-token"
+          },
+          body: hash_including(expected_body)
+        )
+        .to_return(status: 200, body: "{}", headers: { 'Content-Type' => 'application/json' })
+
+      client.broadcast_with_http_info(
+        broadcast_request: Line::Bot::V2::MessagingApi::BroadcastRequest.new(messages: [flex_message])
+      )
+    end
+  end
+
+  describe 'Line::Bot::V2::MessagingApi::ImageCarouselTemplate#initialize' do
+    let(:client) { Line::Bot::V2::MessagingApi::ApiClient.new(channel_access_token: 'test-channel-access-token') }
+
+    it 'creates ImageCarouselTemplate with minimal required fields and broadcasts correctly' do
+      template_message = Line::Bot::V2::MessagingApi::TemplateMessage.new(
+        alt_text: "This is an Image Carousel",
+        template: Line::Bot::V2::MessagingApi::ImageCarouselTemplate.new(
+          columns: [
+            Line::Bot::V2::MessagingApi::ImageCarouselColumn.new(
+              image_url: 'https://example.com/image1.png',
+              action: Line::Bot::V2::MessagingApi::URIAction.new(
+                uri: 'https://example.com',
+                label: 'Go'
+              )
+            ),
+            Line::Bot::V2::MessagingApi::ImageCarouselColumn.new(
+              image_url: 'https://example.com/image2.png',
+              action: Line::Bot::V2::MessagingApi::MessageAction.new(
+                text: 'Hello!',
+                label: 'Say Hello'
+              )
+            )
+          ]
+        )
+      )
+
+      expected_body = {
+        messages: [
+          {
+            type: 'template',
+            altText: 'This is an Image Carousel',
+            template: {
+              type: 'image_carousel', # important: this is the fixed type
+              columns: [
+                {
+                  imageUrl: 'https://example.com/image1.png',
+                  action: {
+                    type: 'uri',
+                    uri: 'https://example.com',
+                    label: 'Go'
+                  }
+                },
+                {
+                  imageUrl: 'https://example.com/image2.png',
+                  action: {
+                    type: 'message',
+                    text: 'Hello!',
+                    label: 'Say Hello'
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        notificationDisabled: false
+      }
+
+      stub_request(:post, "https://api.line.me/v2/bot/message/broadcast")
+        .with(
+          headers: {
+            'Authorization' => "Bearer test-channel-access-token"
+          },
+          body: hash_including(expected_body)
+        )
+        .to_return(status: 200, body: "{}", headers: { 'Content-Type' => 'application/json' })
+
+      client.broadcast_with_http_info(
+        broadcast_request: Line::Bot::V2::MessagingApi::BroadcastRequest.new(messages: [template_message])
+      )
+    end
+  end
+
+  describe 'Line::Bot::V2::MessagingApi::FlexBoxLinearGradient#initialize' do
+    let(:client) { Line::Bot::V2::MessagingApi::ApiClient.new(channel_access_token: 'test-channel-access-token') }
+
+    it 'creates FlexBox with linearGradient background and broadcasts correctly' do
+      flex_message = Line::Bot::V2::MessagingApi::FlexMessage.new(
+        alt_text: 'Test FlexBox with LinearGradient',
+        contents: Line::Bot::V2::MessagingApi::FlexBubble.new(
+          body: Line::Bot::V2::MessagingApi::FlexBox.new(
+            layout: 'vertical',
+            contents: [
+              Line::Bot::V2::MessagingApi::FlexText.new(text: 'Hello World!')
+            ],
+            background: Line::Bot::V2::MessagingApi::FlexBoxLinearGradient.new(
+              angle: '90deg',
+              start_color: '#FF0000',
+              end_color: '#0000FF'
+            )
+          )
+        )
+      )
+
+      expected_body = {
+        messages: [
+          {
+            type: 'flex',
+            altText: 'Test FlexBox with LinearGradient',
+            contents: {
+              type: 'bubble',
+              body: {
+                type: 'box',
+                layout: 'vertical',
+                contents: [
+                  {
+                    type: 'text',
+                    text: 'Hello World!'
+                  }
+                ],
+                background: {
+                  type: 'linearGradient', # important: this is the fixed type
+                  angle: '90deg',
+                  startColor: '#FF0000',
+                  endColor: '#0000FF'
+                }
+              }
+            }
+          }
+        ],
+        notificationDisabled: false
+      }
+
+      stub_request(:post, "https://api.line.me/v2/bot/message/broadcast")
+        .with(
+          headers: {
+            'Authorization' => "Bearer test-channel-access-token"
+          },
+          body: hash_including(expected_body)
+        )
+        .to_return(status: 200, body: "{}", headers: { 'Content-Type' => 'application/json' })
+
+      client.broadcast_with_http_info(
+        broadcast_request: Line::Bot::V2::MessagingApi::BroadcastRequest.new(messages: [flex_message])
+      )
+    end
+  end
+
   describe 'Line::Bot::V2::MessagingApi::FlexMessage#initialize' do
     let(:client) { Line::Bot::V2::MessagingApi::ApiClient.new(channel_access_token: 'test-channel-access-token') }
 


### PR DESCRIPTION
As confirmed [here](https://github.com/line/line-bot-sdk-ruby/pull/461#discussion_r2028004658), the value of type embedded in the class has some peculiarities. There are sufficient tests for deserializing (webhook), so this change adds the missing tests for serialization.