### PR TITLE
Drop requiring type parameter in webhook model for RBS 

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/model.pebble
@@ -38,7 +38,7 @@ module Line
           {% endfor %}
           def initialize: (
             {% for variable in model.model.vars -%}
-            {% if model.model.vendorExtensions.get("x-selector").propertyName != variable.name or packageName == 'webhook' -%}
+            {% if model.model.vendorExtensions.get("x-selector").propertyName != variable.name -%}
             {% if variable.openApiType == 'array' -%}
             {% if variable.items.isModel -%}
             {{ variable.name }}: {{ "Array[#{variable.items.openApiType}]" }}{% if not variable.required %}?{% endif -%}

--- a/sig/line/bot/v2/webhook/model/account_link_event.rbs
+++ b/sig/line/bot/v2/webhook/model/account_link_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor link: LinkContent
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/activated_event.rbs
+++ b/sig/line/bot/v2/webhook/model/activated_event.rbs
@@ -22,7 +22,6 @@ module Line
           attr_accessor chat_control: ChatControl
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/all_mentionee.rbs
+++ b/sig/line/bot/v2/webhook/model/all_mentionee.rbs
@@ -18,7 +18,6 @@ module Line
           attr_accessor length: Integer
           
           def initialize: (
-            type: String,
             index: Integer,
             length: Integer
           ) -> void

--- a/sig/line/bot/v2/webhook/model/attached_module_content.rbs
+++ b/sig/line/bot/v2/webhook/model/attached_module_content.rbs
@@ -17,7 +17,6 @@ module Line
           attr_accessor scopes: Array[String]
           
           def initialize: (
-            type: String,
             bot_id: String,
             scopes: Array[String]
           ) -> void

--- a/sig/line/bot/v2/webhook/model/audio_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/audio_message_content.rbs
@@ -18,7 +18,6 @@ module Line
           attr_accessor duration: Integer?
           
           def initialize: (
-            type: String,
             id: String,
             content_provider: ContentProvider,
             duration: Integer?

--- a/sig/line/bot/v2/webhook/model/beacon_event.rbs
+++ b/sig/line/bot/v2/webhook/model/beacon_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor beacon: BeaconContent
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/bot_resumed_event.rbs
+++ b/sig/line/bot/v2/webhook/model/bot_resumed_event.rbs
@@ -21,7 +21,6 @@ module Line
           attr_accessor delivery_context: DeliveryContext
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/bot_suspended_event.rbs
+++ b/sig/line/bot/v2/webhook/model/bot_suspended_event.rbs
@@ -21,7 +21,6 @@ module Line
           attr_accessor delivery_context: DeliveryContext
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/deactivated_event.rbs
+++ b/sig/line/bot/v2/webhook/model/deactivated_event.rbs
@@ -21,7 +21,6 @@ module Line
           attr_accessor delivery_context: DeliveryContext
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/detached_module_content.rbs
+++ b/sig/line/bot/v2/webhook/model/detached_module_content.rbs
@@ -17,7 +17,6 @@ module Line
           attr_accessor reason: 'bot_deleted'
           
           def initialize: (
-            type: String,
             bot_id: String,
             reason: 'bot_deleted'
           ) -> void

--- a/sig/line/bot/v2/webhook/model/file_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/file_message_content.rbs
@@ -18,7 +18,6 @@ module Line
           attr_accessor file_size: Integer
           
           def initialize: (
-            type: String,
             id: String,
             file_name: String,
             file_size: Integer

--- a/sig/line/bot/v2/webhook/model/follow_event.rbs
+++ b/sig/line/bot/v2/webhook/model/follow_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor follow: FollowDetail
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/group_source.rbs
+++ b/sig/line/bot/v2/webhook/model/group_source.rbs
@@ -17,7 +17,6 @@ module Line
           attr_accessor user_id: String?
           
           def initialize: (
-            type: String,
             group_id: String,
             user_id: String?
           ) -> void

--- a/sig/line/bot/v2/webhook/model/image_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/image_message_content.rbs
@@ -19,7 +19,6 @@ module Line
           attr_accessor quote_token: String
           
           def initialize: (
-            type: String,
             id: String,
             content_provider: ContentProvider,
             image_set: ImageSet?,

--- a/sig/line/bot/v2/webhook/model/join_event.rbs
+++ b/sig/line/bot/v2/webhook/model/join_event.rbs
@@ -22,7 +22,6 @@ module Line
           attr_accessor reply_token: String
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/joined_membership_content.rbs
+++ b/sig/line/bot/v2/webhook/model/joined_membership_content.rbs
@@ -16,7 +16,6 @@ module Line
           attr_accessor membership_id: Integer
           
           def initialize: (
-            type: String,
             membership_id: Integer
           ) -> void
 

--- a/sig/line/bot/v2/webhook/model/leave_event.rbs
+++ b/sig/line/bot/v2/webhook/model/leave_event.rbs
@@ -21,7 +21,6 @@ module Line
           attr_accessor delivery_context: DeliveryContext
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/left_membership_content.rbs
+++ b/sig/line/bot/v2/webhook/model/left_membership_content.rbs
@@ -16,7 +16,6 @@ module Line
           attr_accessor membership_id: Integer
           
           def initialize: (
-            type: String,
             membership_id: Integer
           ) -> void
 

--- a/sig/line/bot/v2/webhook/model/link_things_content.rbs
+++ b/sig/line/bot/v2/webhook/model/link_things_content.rbs
@@ -16,7 +16,6 @@ module Line
           attr_accessor device_id: String
           
           def initialize: (
-            type: String,
             device_id: String
           ) -> void
 

--- a/sig/line/bot/v2/webhook/model/location_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/location_message_content.rbs
@@ -20,7 +20,6 @@ module Line
           attr_accessor longitude: Float
           
           def initialize: (
-            type: String,
             id: String,
             title: String?,
             address: String?,

--- a/sig/line/bot/v2/webhook/model/member_joined_event.rbs
+++ b/sig/line/bot/v2/webhook/model/member_joined_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor joined: JoinedMembers
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/member_left_event.rbs
+++ b/sig/line/bot/v2/webhook/model/member_left_event.rbs
@@ -22,7 +22,6 @@ module Line
           attr_accessor left: LeftMembers
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/membership_event.rbs
+++ b/sig/line/bot/v2/webhook/model/membership_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor membership: MembershipContent
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/message_event.rbs
+++ b/sig/line/bot/v2/webhook/model/message_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor message: MessageContent
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/module_event.rbs
+++ b/sig/line/bot/v2/webhook/model/module_event.rbs
@@ -22,7 +22,6 @@ module Line
           attr_accessor _module: ModuleContent
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/pnp_delivery_completion_event.rbs
+++ b/sig/line/bot/v2/webhook/model/pnp_delivery_completion_event.rbs
@@ -22,7 +22,6 @@ module Line
           attr_accessor delivery: PnpDelivery
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/postback_event.rbs
+++ b/sig/line/bot/v2/webhook/model/postback_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor postback: PostbackContent
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/renewed_membership_content.rbs
+++ b/sig/line/bot/v2/webhook/model/renewed_membership_content.rbs
@@ -16,7 +16,6 @@ module Line
           attr_accessor membership_id: Integer
           
           def initialize: (
-            type: String,
             membership_id: Integer
           ) -> void
 

--- a/sig/line/bot/v2/webhook/model/room_source.rbs
+++ b/sig/line/bot/v2/webhook/model/room_source.rbs
@@ -17,7 +17,6 @@ module Line
           attr_accessor room_id: String
           
           def initialize: (
-            type: String,
             user_id: String?,
             room_id: String
           ) -> void

--- a/sig/line/bot/v2/webhook/model/scenario_result_things_content.rbs
+++ b/sig/line/bot/v2/webhook/model/scenario_result_things_content.rbs
@@ -17,7 +17,6 @@ module Line
           attr_accessor result: ScenarioResult
           
           def initialize: (
-            type: String,
             device_id: String,
             result: ScenarioResult
           ) -> void

--- a/sig/line/bot/v2/webhook/model/sticker_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/sticker_message_content.rbs
@@ -24,7 +24,6 @@ module Line
           attr_accessor quoted_message_id: String?
           
           def initialize: (
-            type: String,
             id: String,
             package_id: String,
             sticker_id: String,

--- a/sig/line/bot/v2/webhook/model/text_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/text_message_content.rbs
@@ -21,7 +21,6 @@ module Line
           attr_accessor quoted_message_id: String?
           
           def initialize: (
-            type: String,
             id: String,
             text: String,
             emojis: Array[Emoji]?,

--- a/sig/line/bot/v2/webhook/model/things_event.rbs
+++ b/sig/line/bot/v2/webhook/model/things_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor things: ThingsContent
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/unfollow_event.rbs
+++ b/sig/line/bot/v2/webhook/model/unfollow_event.rbs
@@ -21,7 +21,6 @@ module Line
           attr_accessor delivery_context: DeliveryContext
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/unlink_things_content.rbs
+++ b/sig/line/bot/v2/webhook/model/unlink_things_content.rbs
@@ -16,7 +16,6 @@ module Line
           attr_accessor device_id: String
           
           def initialize: (
-            type: String,
             device_id: String
           ) -> void
 

--- a/sig/line/bot/v2/webhook/model/unsend_event.rbs
+++ b/sig/line/bot/v2/webhook/model/unsend_event.rbs
@@ -22,7 +22,6 @@ module Line
           attr_accessor unsend: UnsendDetail
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',

--- a/sig/line/bot/v2/webhook/model/user_mentionee.rbs
+++ b/sig/line/bot/v2/webhook/model/user_mentionee.rbs
@@ -20,7 +20,6 @@ module Line
           attr_accessor is_self: bool?
           
           def initialize: (
-            type: String,
             index: Integer,
             length: Integer,
             user_id: String?,

--- a/sig/line/bot/v2/webhook/model/user_source.rbs
+++ b/sig/line/bot/v2/webhook/model/user_source.rbs
@@ -16,7 +16,6 @@ module Line
           attr_accessor user_id: String?
           
           def initialize: (
-            type: String,
             user_id: String?
           ) -> void
 

--- a/sig/line/bot/v2/webhook/model/video_message_content.rbs
+++ b/sig/line/bot/v2/webhook/model/video_message_content.rbs
@@ -19,7 +19,6 @@ module Line
           attr_accessor quote_token: String
           
           def initialize: (
-            type: String,
             id: String,
             duration: Integer?,
             content_provider: ContentProvider,

--- a/sig/line/bot/v2/webhook/model/video_play_complete_event.rbs
+++ b/sig/line/bot/v2/webhook/model/video_play_complete_event.rbs
@@ -23,7 +23,6 @@ module Line
           attr_accessor video_play_complete: VideoPlayComplete
           
           def initialize: (
-            type: String,
             source: Source?,
             timestamp: Integer,
             mode: 'active'|'standby',


### PR DESCRIPTION
In implementation, it donen't require `type` as a keyword parameter. 

ref: https://github.com/line/line-bot-sdk-ruby/blob/a69ea471cdab86dcd043d2021394a59b5457022a/lib/line/bot/v2/webhook/model/account_link_event.rb#L43-L58