### PR TITLE
Handling Version Loading in Gems Properly

### DIFF
--- a/lib/line/bot/v2/http_client.rb
+++ b/lib/line/bot/v2/http_client.rb
@@ -2,6 +2,7 @@ require 'net/http'
 require 'uri'
 require 'json'
 require 'net/http/post/multipart'
+require 'line/bot/v2/version'
 
 module Line
   module Bot

--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -1,10 +1,9 @@
-lib = File.expand_path('lib', __dir__)
-$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'line/bot/v2/version'
+version = File.read("#{__dir__}/lib/line/bot/v2/version.rb").match(/VERSION *= *['"]([^'"]+)/)[1] or raise
+raise "Invalid version format <#{version}>" unless version.match?(/\A\d+\.\d+\.\d+(?:[+-][\w.-]+)?\z/)
 
 Gem::Specification.new do |spec|
   spec.name          = "line-bot-api"
-  spec.version       = Line::Bot::V2::VERSION
+  spec.version       = version
   spec.authors       = ["LINE Corporation"]
   spec.email         = ["kimoto@linecorp.com", "todaka.yusuke@linecorp.com", "masaki_kurosawa@linecorp.com"]
 


### PR DESCRIPTION
If the version file is not loaded in the library code but is loaded in the gemspec file, issues like (https://github.com/line/line-bot-sdk-ruby/pull/379) load errors or missing constants can occur.

To be cautious, the gemspec avoids requiring the version file directly. Instead, it reads the file content. This approach also includes a simple validation to ensure the version string follows the SemVer format, so mistakes in the version file can be detected early.

Additionally, this change fixes an actual case where the version file was not being required properly.