### PR TITLE
Use require 'line-bot-api' instead of require 'line/bot'

### DIFF
--- a/README_v2.md
+++ b/README_v2.md
@@ -47,7 +47,7 @@ gem install line-bot-api
 ```ruby
 # app.rb
 require 'sinatra'
-require 'line/bot'
+require 'line-bot-api'
 
 set :environment, :production
 
@@ -138,7 +138,7 @@ Error details are stored in body.
 
 ```ruby
 require 'json'
-require 'line/bot'
+require 'line-bot-api'
 
 def client
   @client ||= Line::Bot::V2::MessagingApi::ApiClient.new(

--- a/examples/v1/rich_menu/app.rb
+++ b/examples/v1/rich_menu/app.rb
@@ -1,4 +1,4 @@
-require 'line/bot'
+require 'line-bot-api'
 
 def client
     @client ||= Line::Bot::Client.new { |config|

--- a/examples/v2/echobot/app.rb
+++ b/examples/v2/echobot/app.rb
@@ -1,5 +1,5 @@
 require 'sinatra'
-require 'line/bot'
+require 'line-bot-api'
 
 set :environment, :production
 

--- a/examples/v2/kitchensink/app.rb
+++ b/examples/v2/kitchensink/app.rb
@@ -1,6 +1,6 @@
 require 'json'
 require 'sinatra'
-require 'line/bot'
+require 'line-bot-api'
 
 set :environment, :production
 set :app_base_url, ENV['APP_BASE_URL']

--- a/examples/v2/rich_menu/app.rb
+++ b/examples/v2/rich_menu/app.rb
@@ -1,4 +1,4 @@
-require 'line/bot'
+require 'line-bot-api'
 
 def client
   @client ||= Line::Bot::V2::MessagingApi::ApiClient.new(

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,4 +2,4 @@ $LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'webmock/rspec'
 
-require 'line/bot'
+require 'line-bot-api'


### PR DESCRIPTION
From v2, we recommend using `require 'line-bot-api'` instead of `require 'line/bot'`. Of course, `require 'line/bot'` will still work, but using the name that matches the gem is clearer. Additionally, `'line/bot'` is an internal representation and not something users need to be aware of.

This is not a breaking change. It will still work with `require 'line/bot'`. However, I don't think we need to guarantee this behavior from v2.

Close https://github.com/line/line-bot-sdk-ruby/issues/495