### PR TITLE
Fix initializing for plain String of Ruby

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
@@ -72,6 +72,7 @@ module Line
             {% if model.model.vendorExtensions.get("x-selector") != null %}@{{model.model.vendorExtensions.get("x-selector").propertyName}} = "{{model.model.vendorExtensions.get("x-selector").mappingName}}"{%- endif -%}
             {%- for property in model.model.vars %}
             {% if property.isArray -%}
+            {%- if property.items.isModel -%}
             @{{ property.name }} = {{ property.name }}{{ property.required ? '' : '&'  }}.map do |item|
               if item.is_a?(Hash)
                 Line::Bot::V2::{{ packageName | camelize }}::{{ property.complexType }}.create(**item) # steep:ignore InsufficientKeywordArguments
@@ -79,6 +80,9 @@ module Line
                 item
               end
             end
+            {%- else -%}
+            @{{ property.name }} = {{ property.name }}
+            {%- endif -%}
             {%- elseif property.isModel -%}
             @{{ property.name }} = {{ property.name }}.is_a?(Line::Bot::V2::{{ packageName | camelize }}::{{ property.baseType }}){% if not property.required %} || {{ property.name }}.nil?{% endif %} ? {{ property.name }} : Line::Bot::V2::{{ packageName | camelize }}::{{ property.baseType }}.create(**{{ property.name }}) # steep:ignore
             {%- elseif model.model.vendorExtensions.get("x-selector").propertyName != property.name -%}

--- a/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
@@ -24,13 +24,7 @@ module Line
             **dynamic_attributes
           )
             
-            @kids = kids.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::ChannelAccessToken::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @kids = kids
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/liff/model/add_liff_app_request.rb
+++ b/lib/line/bot/v2/liff/model/add_liff_app_request.rb
@@ -52,13 +52,7 @@ module Line
             @description = description
             @features = features.is_a?(Line::Bot::V2::Liff::LiffFeatures) || features.nil? ? features : Line::Bot::V2::Liff::LiffFeatures.create(**features) # steep:ignore
             @permanent_link_pattern = permanent_link_pattern
-            @scope = scope&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::Liff::LiffScope.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @scope = scope
             @bot_prompt = bot_prompt
 
             dynamic_attributes.each do |key, value|

--- a/lib/line/bot/v2/liff/model/liff_app.rb
+++ b/lib/line/bot/v2/liff/model/liff_app.rb
@@ -57,13 +57,7 @@ module Line
             @description = description
             @features = features.is_a?(Line::Bot::V2::Liff::LiffFeatures) || features.nil? ? features : Line::Bot::V2::Liff::LiffFeatures.create(**features) # steep:ignore
             @permanent_link_pattern = permanent_link_pattern
-            @scope = scope&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::Liff::LiffScope.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @scope = scope
             @bot_prompt = bot_prompt
 
             dynamic_attributes.each do |key, value|

--- a/lib/line/bot/v2/liff/model/update_liff_app_request.rb
+++ b/lib/line/bot/v2/liff/model/update_liff_app_request.rb
@@ -52,13 +52,7 @@ module Line
             @description = description
             @features = features.is_a?(Line::Bot::V2::Liff::LiffFeatures) || features.nil? ? features : Line::Bot::V2::Liff::LiffFeatures.create(**features) # steep:ignore
             @permanent_link_pattern = permanent_link_pattern
-            @scope = scope&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::Liff::LiffScope.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @scope = scope
             @bot_prompt = bot_prompt
 
             dynamic_attributes.each do |key, value|

--- a/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
@@ -28,13 +28,7 @@ module Line
           )
             @type = "appType"
             
-            @one_of = one_of&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::AppTypeDemographic.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @one_of = one_of
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
@@ -28,13 +28,7 @@ module Line
           )
             @type = "area"
             
-            @one_of = one_of&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::AreaDemographic.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @one_of = one_of
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
@@ -28,13 +28,7 @@ module Line
           )
             @type = "gender"
             
-            @one_of = one_of&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::GenderDemographic.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @one_of = one_of
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
@@ -28,13 +28,7 @@ module Line
             **dynamic_attributes
           )
             
-            @custom_aggregation_units = custom_aggregation_units.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @custom_aggregation_units = custom_aggregation_units
             @_next = _next
 
             dynamic_attributes.each do |key, value|

--- a/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
@@ -28,13 +28,7 @@ module Line
             **dynamic_attributes
           )
             
-            @user_ids = user_ids.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @user_ids = user_ids
             @_next = _next
 
             dynamic_attributes.each do |key, value|

--- a/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
@@ -29,13 +29,7 @@ module Line
             **dynamic_attributes
           )
             
-            @user_ids = user_ids.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @user_ids = user_ids
             @_next = _next
 
             dynamic_attributes.each do |key, value|

--- a/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
@@ -27,13 +27,7 @@ module Line
             **dynamic_attributes
           )
             
-            @member_ids = member_ids.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @member_ids = member_ids
             @_next = _next
 
             dynamic_attributes.each do |key, value|

--- a/lib/line/bot/v2/messaging_api/model/membership.rb
+++ b/lib/line/bot/v2/messaging_api/model/membership.rb
@@ -70,13 +70,7 @@ module Line
             @membership_id = membership_id
             @title = title
             @description = description
-            @benefits = benefits.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @benefits = benefits
             @price = price
             @currency = currency
             @member_count = member_count

--- a/lib/line/bot/v2/messaging_api/model/multicast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/multicast_request.rb
@@ -45,21 +45,9 @@ module Line
                 item
               end
             end
-            @to = to.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @to = to
             @notification_disabled = notification_disabled
-            @custom_aggregation_units = custom_aggregation_units&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @custom_aggregation_units = custom_aggregation_units
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/messaging_api/model/push_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/push_message_request.rb
@@ -47,13 +47,7 @@ module Line
               end
             end
             @notification_disabled = notification_disabled
-            @custom_aggregation_units = custom_aggregation_units&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @custom_aggregation_units = custom_aggregation_units
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
@@ -29,13 +29,7 @@ module Line
           )
             
             @rich_menu_id = rich_menu_id
-            @user_ids = user_ids.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @user_ids = user_ids
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
@@ -23,13 +23,7 @@ module Line
             **dynamic_attributes
           )
             
-            @user_ids = user_ids.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @user_ids = user_ids
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
@@ -51,13 +51,7 @@ module Line
             @membership_id = membership_id
             @title = title
             @description = description
-            @benefits = benefits.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::MessagingApi::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @benefits = benefits
             @price = price
             @currency = currency
 

--- a/lib/line/bot/v2/module_attach/model/attach_module_response.rb
+++ b/lib/line/bot/v2/module_attach/model/attach_module_response.rb
@@ -29,13 +29,7 @@ module Line
           )
             
             @bot_id = bot_id
-            @scopes = scopes.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::ModuleAttach::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @scopes = scopes
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/webhook/model/attached_module_content.rb
+++ b/lib/line/bot/v2/webhook/model/attached_module_content.rb
@@ -34,13 +34,7 @@ module Line
             @type = "attached"
             
             @bot_id = bot_id
-            @scopes = scopes.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::Webhook::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @scopes = scopes
 
             dynamic_attributes.each do |key, value|
               self.class.attr_accessor key

--- a/lib/line/bot/v2/webhook/model/sticker_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/sticker_message_content.rb
@@ -68,13 +68,7 @@ module Line
             @package_id = package_id
             @sticker_id = sticker_id
             @sticker_resource_type = sticker_resource_type
-            @keywords = keywords&.map do |item|
-              if item.is_a?(Hash)
-                Line::Bot::V2::Webhook::string.create(**item) # steep:ignore InsufficientKeywordArguments
-              else
-                item
-              end
-            end
+            @keywords = keywords
             @text = text
             @quote_token = quote_token
             @quoted_message_id = quoted_message_id


### PR DESCRIPTION
Fix the problem that the initialization process of a non-existent class was interrupted during the initialization of the model, when it should be set to the instance variable as is in the case of an `Array[String]` or `Array[String, nil]` type.

Resolve https://github.com/line/line-bot-sdk-ruby/issues/498