### PR TITLE
Missing variable definition in class for RBS

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
@@ -8,6 +8,7 @@ module Line
     module V2
       module {{ packageName | camelize }}
         class Api{{ operations.classname.indexOf('Blob') != -1 ? 'Blob' : '' }}Client
+          @http_client: HttpClient
           def initialize: (
             base_url: String?{% if packageName == 'channel_access_token' %}{% elseif packageName == 'module_attach' %},
             channel_id: String,

--- a/sig/line/bot/v2/channel_access_token/api/channel_access_token_client.rbs
+++ b/sig/line/bot/v2/channel_access_token/api/channel_access_token_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module ChannelAccessToken
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             http_options: Hash[String|Symbol, untyped]

--- a/sig/line/bot/v2/insight/api/insight_client.rbs
+++ b/sig/line/bot/v2/insight/api/insight_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module Insight
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/liff/api/liff_client.rbs
+++ b/sig/line/bot/v2/liff/api/liff_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module Liff
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/manage_audience/api/manage_audience_blob_client.rbs
+++ b/sig/line/bot/v2/manage_audience/api/manage_audience_blob_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module ManageAudience
         class ApiBlobClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
+++ b/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module ManageAudience
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
+++ b/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module MessagingApi
         class ApiBlobClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/messaging_api/api/messaging_api_client.rbs
+++ b/sig/line/bot/v2/messaging_api/api/messaging_api_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module MessagingApi
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/module/api/line_module_client.rbs
+++ b/sig/line/bot/v2/module/api/line_module_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module Module
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/module_attach/api/line_module_attach_client.rbs
+++ b/sig/line/bot/v2/module_attach/api/line_module_attach_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module ModuleAttach
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_id: String,

--- a/sig/line/bot/v2/shop/api/shop_client.rbs
+++ b/sig/line/bot/v2/shop/api/shop_client.rbs
@@ -12,6 +12,7 @@ module Line
     module V2
       module Shop
         class ApiClient
+          @http_client: HttpClient
           def initialize: (
             base_url: String?,
             channel_access_token: String,

--- a/sig/line/bot/v2/webhook_parser.rbs
+++ b/sig/line/bot/v2/webhook_parser.rbs
@@ -4,6 +4,7 @@ module Line
       class WebhookParser
         class InvalidSignatureError < ::StandardError
         end
+        @channel_secret: String
 
         def initialize: (channel_secret: String) -> void
 


### PR DESCRIPTION
When using `@variable` within a class, if we don't write its definition in the RBS file, `@variable.hoge` will be inferred as `untyped`.

As a result, all subsequent values will be considered `untyped`, and mistakes cannot be detected. (like https://github.com/line/line-bot-sdk-ruby/issues/499)

To prevent this, this change adds type definitions for variables within the class. Note steep with strict mode can show hint about this.