### PR TITLE
Mark as optional parameter for RBS in Client#initialize

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
@@ -10,11 +10,15 @@ module Line
         class Api{{ operations.classname.indexOf('Blob') != -1 ? 'Blob' : '' }}Client
           @http_client: HttpClient
           def initialize: (
-            base_url: String?{% if packageName == 'channel_access_token' %}{% elseif packageName == 'module_attach' %},
+            ?base_url: String?
+            {%- if packageName == 'channel_access_token' -%}
+            {%- elseif packageName == 'module_attach' %},
             channel_id: String,
-            channel_secret: String{% else %},
-            channel_access_token: String{% endif %},
-            http_options: Hash[String|Symbol, untyped]
+            channel_secret: String
+            {%- else %},
+            channel_access_token: String
+            {%- endif %},
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
           {%- for op in operations.operation %}
 

--- a/sig/line/bot/v2/channel_access_token/api/channel_access_token_client.rbs
+++ b/sig/line/bot/v2/channel_access_token/api/channel_access_token_client.rbs
@@ -14,8 +14,8 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
-            http_options: Hash[String|Symbol, untyped]
+            ?base_url: String?,
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Gets all valid channel access token key IDs.

--- a/sig/line/bot/v2/insight/api/insight_client.rbs
+++ b/sig/line/bot/v2/insight/api/insight_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Retrieves the demographic attributes for a LINE Official Account's friends.You can only retrieve information about friends for LINE Official Accounts created by users in Japan (JP), Thailand (TH), Taiwan (TW) and Indonesia (ID). 

--- a/sig/line/bot/v2/liff/api/liff_client.rbs
+++ b/sig/line/bot/v2/liff/api/liff_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Adding the LIFF app to a channel

--- a/sig/line/bot/v2/manage_audience/api/manage_audience_blob_client.rbs
+++ b/sig/line/bot/v2/manage_audience/api/manage_audience_blob_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiBlobClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Add user IDs or Identifiers for Advertisers (IFAs) to an audience for uploading user IDs (by file).

--- a/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
+++ b/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Activate audience

--- a/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
+++ b/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiBlobClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Download image, video, and audio data sent from users.

--- a/sig/line/bot/v2/messaging_api/api/messaging_api_client.rbs
+++ b/sig/line/bot/v2/messaging_api/api/messaging_api_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Sends a message to multiple users at any time.

--- a/sig/line/bot/v2/module/api/line_module_client.rbs
+++ b/sig/line/bot/v2/module/api/line_module_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # If the Standby Channel wants to take the initiative (Chat Control), it calls the Acquire Control API. The channel that was previously an Active Channel will automatically switch to a Standby Channel. 

--- a/sig/line/bot/v2/module_attach/api/line_module_attach_client.rbs
+++ b/sig/line/bot/v2/module_attach/api/line_module_attach_client.rbs
@@ -14,10 +14,10 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_id: String,
             channel_secret: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Attach by operation of the module channel provider

--- a/sig/line/bot/v2/shop/api/shop_client.rbs
+++ b/sig/line/bot/v2/shop/api/shop_client.rbs
@@ -14,9 +14,9 @@ module Line
         class ApiClient
           @http_client: HttpClient
           def initialize: (
-            base_url: String?,
+            ?base_url: String?,
             channel_access_token: String,
-            http_options: Hash[String|Symbol, untyped]
+            ?http_options: Hash[String|Symbol, untyped]
           ) -> void
 
           # Sends a mission sticker.


### PR DESCRIPTION
This resolves current inconsistency between implementation and RBS in Client#initialize like below
```
lib/line/bot/v2/manage_audience/api/manage_audience_blob_client.rb:38:25: [error] The method parameter has different kind from the declaration `(base_url: (::String | nil), channel_access_token: ::String, http_options: ::Hash[(::String | ::Symbol), untyped]) -> void`
│ Diagnostic ID: Ruby::DifferentMethodParameterKind
│
└           def initialize(base_url: nil, channel_access_token:, http_options: {})
...
```

(one of tasks for https://github.com/line/line-bot-sdk-ruby/issues/526)