### PR TITLE
Mark as optional parameter for RBS in Client#<request>

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
@@ -38,7 +38,7 @@ module Line
           {% endif -%}
           def {{op.nickname}}_with_http_info: (
             {%- for param in op.allParams %}
-            {{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
+            {{ param.required ? '' : '?' }}{{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
             {% endfor %}
           ) -> [({% for response in op.responses %}{{ response.baseType == 'object' or response.baseType == null ? 'String?' : response.dataType }}{{ loop.last ? '' : '|' }}{% endfor %}), Integer, Hash[String, String]]
 
@@ -58,7 +58,7 @@ module Line
           {% endif -%}
           def {{op.nickname}}: (
             {%- for param in op.allParams %}
-            {{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
+            {{ param.required ? '' : '?' }}{{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
             {% endfor %}
           ) -> ({% for response in op.responses %}{{ response.baseType == 'object' or response.baseType == null ? 'String?' : response.dataType }}{{ loop.last ? '' : '|' }}{% endfor %}){% endfor %}
         end

--- a/sig/line/bot/v2/channel_access_token/api/channel_access_token_client.rbs
+++ b/sig/line/bot/v2/channel_access_token/api/channel_access_token_client.rbs
@@ -95,11 +95,11 @@ module Line
           # @param client_secret Channel secret.
           # @see https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token
           def issue_stateless_channel_token_with_http_info: (
-            grant_type: String?, 
-            client_assertion_type: String?, 
-            client_assertion: String?, 
-            client_id: String?, 
-            client_secret: String?
+            ?grant_type: String?, 
+            ?client_assertion_type: String?, 
+            ?client_assertion: String?, 
+            ?client_id: String?, 
+            ?client_secret: String?
           ) -> [(IssueStatelessChannelAccessTokenResponse), Integer, Hash[String, String]]
 
           # Issues a new stateless channel access token, which doesn't have max active token limit unlike the other token types. The newly issued token is only valid for 15 minutes but can not be revoked until it naturally expires. 
@@ -111,11 +111,11 @@ module Line
           # @param client_secret Channel secret.
           # @see https://developers.line.biz/en/reference/messaging-api/#issue-stateless-channel-access-token
           def issue_stateless_channel_token: (
-            grant_type: String?, 
-            client_assertion_type: String?, 
-            client_assertion: String?, 
-            client_id: String?, 
-            client_secret: String?
+            ?grant_type: String?, 
+            ?client_assertion_type: String?, 
+            ?client_assertion: String?, 
+            ?client_id: String?, 
+            ?client_secret: String?
           ) -> (IssueStatelessChannelAccessTokenResponse)
 
           # Revoke short-lived or long-lived channel access token

--- a/sig/line/bot/v2/insight/api/insight_client.rbs
+++ b/sig/line/bot/v2/insight/api/insight_client.rbs
@@ -52,7 +52,7 @@ module Line
           # @param date Date for which to retrieve the number of followers.  Format: yyyyMMdd (e.g. 20191231) Timezone: UTC+9 
           # @see https://developers.line.biz/en/reference/messaging-api/#get-number-of-followers
           def get_number_of_followers_with_http_info: (
-            date: String?
+            ?date: String?
           ) -> [(GetNumberOfFollowersResponse), Integer, Hash[String, String]]
 
           # Returns the number of users who have added the LINE Official Account on or before a specified date. 
@@ -60,7 +60,7 @@ module Line
           # @param date Date for which to retrieve the number of followers.  Format: yyyyMMdd (e.g. 20191231) Timezone: UTC+9 
           # @see https://developers.line.biz/en/reference/messaging-api/#get-number-of-followers
           def get_number_of_followers: (
-            date: String?
+            ?date: String?
           ) -> (GetNumberOfFollowersResponse)
 
           # Returns the number of messages sent from LINE Official Account on a specified day. 

--- a/sig/line/bot/v2/manage_audience/api/manage_audience_blob_client.rbs
+++ b/sig/line/bot/v2/manage_audience/api/manage_audience_blob_client.rbs
@@ -27,8 +27,8 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#update-upload-audience-group-by-file
           def add_user_ids_to_audience_with_http_info: (
             file: File, 
-            audience_group_id: Integer?, 
-            upload_description: String?
+            ?audience_group_id: Integer?, 
+            ?upload_description: String?
           ) -> [(String?), Integer, Hash[String, String]]
 
           # Add user IDs or Identifiers for Advertisers (IFAs) to an audience for uploading user IDs (by file).
@@ -39,8 +39,8 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#update-upload-audience-group-by-file
           def add_user_ids_to_audience: (
             file: File, 
-            audience_group_id: Integer?, 
-            upload_description: String?
+            ?audience_group_id: Integer?, 
+            ?upload_description: String?
           ) -> (String?)
 
           # Create audience for uploading user IDs (by file).
@@ -52,9 +52,9 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#create-upload-audience-group-by-file
           def create_audience_for_uploading_user_ids_with_http_info: (
             file: File, 
-            description: String?, 
-            is_ifa_audience: bool?, 
-            upload_description: String?
+            ?description: String?, 
+            ?is_ifa_audience: bool?, 
+            ?upload_description: String?
           ) -> [(CreateAudienceGroupResponse), Integer, Hash[String, String]]
 
           # Create audience for uploading user IDs (by file).
@@ -66,9 +66,9 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#create-upload-audience-group-by-file
           def create_audience_for_uploading_user_ids: (
             file: File, 
-            description: String?, 
-            is_ifa_audience: bool?, 
-            upload_description: String?
+            ?description: String?, 
+            ?is_ifa_audience: bool?, 
+            ?upload_description: String?
           ) -> (CreateAudienceGroupResponse)
         end
       end

--- a/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
+++ b/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
@@ -126,11 +126,11 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-audience-groups
           def get_audience_groups_with_http_info: (
             page: Integer, 
-            description: String?, 
-            status: AudienceGroupStatus?, 
-            size: Integer?, 
-            includes_external_public_groups: bool?, 
-            create_route: AudienceGroupCreateRoute?
+            ?description: String?, 
+            ?status: AudienceGroupStatus?, 
+            ?size: Integer?, 
+            ?includes_external_public_groups: bool?, 
+            ?create_route: AudienceGroupCreateRoute?
           ) -> [(GetAudienceGroupsResponse), Integer, Hash[String, String]]
 
           # Gets data for more than one audience.
@@ -144,11 +144,11 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-audience-groups
           def get_audience_groups: (
             page: Integer, 
-            description: String?, 
-            status: AudienceGroupStatus?, 
-            size: Integer?, 
-            includes_external_public_groups: bool?, 
-            create_route: AudienceGroupCreateRoute?
+            ?description: String?, 
+            ?status: AudienceGroupStatus?, 
+            ?size: Integer?, 
+            ?includes_external_public_groups: bool?, 
+            ?create_route: AudienceGroupCreateRoute?
           ) -> (GetAudienceGroupsResponse)
 
           # Gets audience data.
@@ -178,11 +178,23 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-shared-audience-list
           def get_shared_audience_groups_with_http_info: (
             page: Integer, 
+<<<<<<< HEAD
             description: String?, 
             status: AudienceGroupStatus?, 
             size: Integer?, 
             create_route: AudienceGroupCreateRoute?, 
             includes_owned_audience_groups: bool?
+||||||| parent of c460bed (NO-ISSUE gen)
+            description: String?, 
+            status: AudienceGroupStatus?, 
+            size: Integer?, 
+            create_route: AudienceGroupCreateRoute?
+=======
+            ?description: String?, 
+            ?status: AudienceGroupStatus?, 
+            ?size: Integer?, 
+            ?create_route: AudienceGroupCreateRoute?
+>>>>>>> c460bed (NO-ISSUE gen)
           ) -> [(GetSharedAudienceGroupsResponse), Integer, Hash[String, String]]
 
           # Gets data for more than one audience, including those shared by the Business Manager.
@@ -196,11 +208,23 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-shared-audience-list
           def get_shared_audience_groups: (
             page: Integer, 
+<<<<<<< HEAD
             description: String?, 
             status: AudienceGroupStatus?, 
             size: Integer?, 
             create_route: AudienceGroupCreateRoute?, 
             includes_owned_audience_groups: bool?
+||||||| parent of c460bed (NO-ISSUE gen)
+            description: String?, 
+            status: AudienceGroupStatus?, 
+            size: Integer?, 
+            create_route: AudienceGroupCreateRoute?
+=======
+            ?description: String?, 
+            ?status: AudienceGroupStatus?, 
+            ?size: Integer?, 
+            ?create_route: AudienceGroupCreateRoute?
+>>>>>>> c460bed (NO-ISSUE gen)
           ) -> (GetSharedAudienceGroupsResponse)
 
           # Renames an existing audience.

--- a/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
+++ b/sig/line/bot/v2/manage_audience/api/manage_audience_client.rbs
@@ -178,23 +178,11 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-shared-audience-list
           def get_shared_audience_groups_with_http_info: (
             page: Integer, 
-<<<<<<< HEAD
-            description: String?, 
-            status: AudienceGroupStatus?, 
-            size: Integer?, 
-            create_route: AudienceGroupCreateRoute?, 
-            includes_owned_audience_groups: bool?
-||||||| parent of c460bed (NO-ISSUE gen)
-            description: String?, 
-            status: AudienceGroupStatus?, 
-            size: Integer?, 
-            create_route: AudienceGroupCreateRoute?
-=======
             ?description: String?, 
             ?status: AudienceGroupStatus?, 
             ?size: Integer?, 
-            ?create_route: AudienceGroupCreateRoute?
->>>>>>> c460bed (NO-ISSUE gen)
+            ?create_route: AudienceGroupCreateRoute?, 
+            ?includes_owned_audience_groups: bool?
           ) -> [(GetSharedAudienceGroupsResponse), Integer, Hash[String, String]]
 
           # Gets data for more than one audience, including those shared by the Business Manager.
@@ -208,23 +196,11 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-shared-audience-list
           def get_shared_audience_groups: (
             page: Integer, 
-<<<<<<< HEAD
-            description: String?, 
-            status: AudienceGroupStatus?, 
-            size: Integer?, 
-            create_route: AudienceGroupCreateRoute?, 
-            includes_owned_audience_groups: bool?
-||||||| parent of c460bed (NO-ISSUE gen)
-            description: String?, 
-            status: AudienceGroupStatus?, 
-            size: Integer?, 
-            create_route: AudienceGroupCreateRoute?
-=======
             ?description: String?, 
             ?status: AudienceGroupStatus?, 
             ?size: Integer?, 
-            ?create_route: AudienceGroupCreateRoute?
->>>>>>> c460bed (NO-ISSUE gen)
+            ?create_route: AudienceGroupCreateRoute?, 
+            ?includes_owned_audience_groups: bool?
           ) -> (GetSharedAudienceGroupsResponse)
 
           # Renames an existing audience.

--- a/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
+++ b/sig/line/bot/v2/messaging_api/api/messaging_api_blob_client.rbs
@@ -90,7 +90,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#upload-rich-menu-image
           def set_rich_menu_image_with_http_info: (
             rich_menu_id: String, 
-            body: File?
+            ?body: File?
           ) -> [(String?), Integer, Hash[String, String]]
 
           # Upload rich menu image
@@ -100,7 +100,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#upload-rich-menu-image
           def set_rich_menu_image: (
             rich_menu_id: String, 
-            body: File?
+            ?body: File?
           ) -> (String?)
         end
       end

--- a/sig/line/bot/v2/messaging_api/api/messaging_api_client.rbs
+++ b/sig/line/bot/v2/messaging_api/api/messaging_api_client.rbs
@@ -26,7 +26,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
           def broadcast_with_http_info: (
             broadcast_request: BroadcastRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> [(String?|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse), Integer, Hash[String, String]]
 
           # Sends a message to multiple users at any time.
@@ -36,7 +36,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-broadcast-message
           def broadcast: (
             broadcast_request: BroadcastRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> (String?|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse)
 
           # Cancel default rich menu
@@ -121,8 +121,8 @@ module Line
           # @param start Value of the continuation token found in the next property of the JSON object returned in the response. If you can't get all the aggregation units in one request, include this parameter to get the remaining array. 
           # @see https://developers.line.biz/en/reference/messaging-api/#get-name-list-of-units-used-this-month
           def get_aggregation_unit_name_list_with_http_info: (
-            limit: String?, 
-            start: String?
+            ?limit: String?, 
+            ?start: String?
           ) -> [(GetAggregationUnitNameListResponse), Integer, Hash[String, String]]
 
           # Get name list of units used this month
@@ -131,8 +131,8 @@ module Line
           # @param start Value of the continuation token found in the next property of the JSON object returned in the response. If you can't get all the aggregation units in one request, include this parameter to get the remaining array. 
           # @see https://developers.line.biz/en/reference/messaging-api/#get-name-list-of-units-used-this-month
           def get_aggregation_unit_name_list: (
-            limit: String?, 
-            start: String?
+            ?limit: String?, 
+            ?start: String?
           ) -> (GetAggregationUnitNameListResponse)
 
           # Get number of units used this month
@@ -177,8 +177,8 @@ module Line
           # @param limit The maximum number of user IDs to retrieve in a single request.
           # @see https://developers.line.biz/en/reference/messaging-api/#get-follower-ids
           def get_followers_with_http_info: (
-            start: String?, 
-            limit: Integer?
+            ?start: String?, 
+            ?limit: Integer?
           ) -> [(GetFollowersResponse), Integer, Hash[String, String]]
 
           # Get a list of users who added your LINE Official Account as a friend
@@ -187,8 +187,8 @@ module Line
           # @param limit The maximum number of user IDs to retrieve in a single request.
           # @see https://developers.line.biz/en/reference/messaging-api/#get-follower-ids
           def get_followers: (
-            start: String?, 
-            limit: Integer?
+            ?start: String?, 
+            ?limit: Integer?
           ) -> (GetFollowersResponse)
 
           # Get number of users in a group chat
@@ -234,7 +234,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-group-member-user-ids
           def get_group_members_ids_with_http_info: (
             group_id: String, 
-            start: String?
+            ?start: String?
           ) -> [(MembersIdsResponse), Integer, Hash[String, String]]
 
           # Get group chat member user IDs
@@ -244,7 +244,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-group-member-user-ids
           def get_group_members_ids: (
             group_id: String, 
-            start: String?
+            ?start: String?
           ) -> (MembersIdsResponse)
 
           # Get group chat summary
@@ -271,8 +271,8 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-membership-user-ids
           def get_joined_membership_users_with_http_info: (
             membership_id: Integer, 
-            start: String?, 
-            limit: Integer?
+            ?start: String?, 
+            ?limit: Integer?
           ) -> [(GetJoinedMembershipUsersResponse|ErrorResponse|ErrorResponse), Integer, Hash[String, String]]
 
           # Get a list of user IDs who joined the membership.
@@ -283,8 +283,8 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-membership-user-ids
           def get_joined_membership_users: (
             membership_id: Integer, 
-            start: String?, 
-            limit: Integer?
+            ?start: String?, 
+            ?limit: Integer?
           ) -> (GetJoinedMembershipUsersResponse|ErrorResponse|ErrorResponse)
 
           # Get a list of memberships.
@@ -582,7 +582,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-room-member-user-ids
           def get_room_members_ids_with_http_info: (
             room_id: String, 
-            start: String?
+            ?start: String?
           ) -> [(MembersIdsResponse), Integer, Hash[String, String]]
 
           # Get multi-person chat member user IDs
@@ -592,7 +592,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#get-room-member-user-ids
           def get_room_members_ids: (
             room_id: String, 
-            start: String?
+            ?start: String?
           ) -> (MembersIdsResponse)
 
           # Get webhook endpoint information
@@ -714,7 +714,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
           def multicast_with_http_info: (
             multicast_request: MulticastRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> [(String?|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse), Integer, Hash[String, String]]
 
           # An API that efficiently sends the same message to multiple user IDs. You can't send messages to group chats or multi-person chats.
@@ -724,7 +724,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-multicast-message
           def multicast: (
             multicast_request: MulticastRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> (String?|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse)
 
           # Send narrowcast message
@@ -734,7 +734,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
           def narrowcast_with_http_info: (
             narrowcast_request: NarrowcastRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> [(String?|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse), Integer, Hash[String, String]]
 
           # Send narrowcast message
@@ -744,7 +744,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-narrowcast-message
           def narrowcast: (
             narrowcast_request: NarrowcastRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> (String?|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse)
 
           # Sends a message to a user, group chat, or multi-person chat at any time.
@@ -754,7 +754,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-push-message
           def push_message_with_http_info: (
             push_message_request: PushMessageRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> [(PushMessageResponse|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse), Integer, Hash[String, String]]
 
           # Sends a message to a user, group chat, or multi-person chat at any time.
@@ -764,7 +764,7 @@ module Line
           # @see https://developers.line.biz/en/reference/messaging-api/#send-push-message
           def push_message: (
             push_message_request: PushMessageRequest, 
-            x_line_retry_key: String?
+            ?x_line_retry_key: String?
           ) -> (PushMessageResponse|ErrorResponse|ErrorResponse|ErrorResponse|ErrorResponse)
 
           # Send LINE notification message
@@ -774,7 +774,7 @@ module Line
           # @see https://developers.line.biz/en/reference/partner-docs/#send-line-notification-message
           def push_messages_by_phone_with_http_info: (
             pnp_messages_request: PnpMessagesRequest, 
-            x_line_delivery_tag: String?
+            ?x_line_delivery_tag: String?
           ) -> [(String?|ErrorResponse), Integer, Hash[String, String]]
 
           # Send LINE notification message
@@ -784,7 +784,7 @@ module Line
           # @see https://developers.line.biz/en/reference/partner-docs/#send-line-notification-message
           def push_messages_by_phone: (
             pnp_messages_request: PnpMessagesRequest, 
-            x_line_delivery_tag: String?
+            ?x_line_delivery_tag: String?
           ) -> (String?|ErrorResponse)
 
           # Send reply message
@@ -872,7 +872,7 @@ module Line
           # @param test_webhook_endpoint_request 
           # @see https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
           def test_webhook_endpoint_with_http_info: (
-            test_webhook_endpoint_request: TestWebhookEndpointRequest?
+            ?test_webhook_endpoint_request: TestWebhookEndpointRequest?
           ) -> [(TestWebhookEndpointResponse), Integer, Hash[String, String]]
 
           # Test webhook endpoint
@@ -880,7 +880,7 @@ module Line
           # @param test_webhook_endpoint_request 
           # @see https://developers.line.biz/en/reference/messaging-api/#test-webhook-endpoint
           def test_webhook_endpoint: (
-            test_webhook_endpoint_request: TestWebhookEndpointRequest?
+            ?test_webhook_endpoint_request: TestWebhookEndpointRequest?
           ) -> (TestWebhookEndpointResponse)
 
           # Unlink rich menu from user

--- a/sig/line/bot/v2/module/api/line_module_client.rbs
+++ b/sig/line/bot/v2/module/api/line_module_client.rbs
@@ -26,7 +26,7 @@ module Line
           # @see https://developers.line.biz/en/reference/partner-docs/#acquire-control-api
           def acquire_chat_control_with_http_info: (
             chat_id: String, 
-            acquire_chat_control_request: AcquireChatControlRequest?
+            ?acquire_chat_control_request: AcquireChatControlRequest?
           ) -> [(String?), Integer, Hash[String, String]]
 
           # If the Standby Channel wants to take the initiative (Chat Control), it calls the Acquire Control API. The channel that was previously an Active Channel will automatically switch to a Standby Channel. 
@@ -36,7 +36,7 @@ module Line
           # @see https://developers.line.biz/en/reference/partner-docs/#acquire-control-api
           def acquire_chat_control: (
             chat_id: String, 
-            acquire_chat_control_request: AcquireChatControlRequest?
+            ?acquire_chat_control_request: AcquireChatControlRequest?
           ) -> (String?)
 
           # The module channel admin calls the Detach API to detach the module channel from a LINE Official Account.
@@ -44,7 +44,7 @@ module Line
           # @param detach_module_request 
           # @see https://developers.line.biz/en/reference/partner-docs/#unlink-detach-module-channel-by-operation-mc-admin
           def detach_module_with_http_info: (
-            detach_module_request: DetachModuleRequest?
+            ?detach_module_request: DetachModuleRequest?
           ) -> [(String?), Integer, Hash[String, String]]
 
           # The module channel admin calls the Detach API to detach the module channel from a LINE Official Account.
@@ -52,7 +52,7 @@ module Line
           # @param detach_module_request 
           # @see https://developers.line.biz/en/reference/partner-docs/#unlink-detach-module-channel-by-operation-mc-admin
           def detach_module: (
-            detach_module_request: DetachModuleRequest?
+            ?detach_module_request: DetachModuleRequest?
           ) -> (String?)
 
           # Gets a list of basic information about the bots of multiple LINE Official Accounts that have attached module channels.
@@ -61,8 +61,8 @@ module Line
           # @param limit Specify the maximum number of bots that you get basic information from. The default value is 100. Max value: 100 
           # @see https://developers.line.biz/en/reference/partner-docs/#get-multiple-bot-info-api
           def get_modules_with_http_info: (
-            start: String?, 
-            limit: Integer?
+            ?start: String?, 
+            ?limit: Integer?
           ) -> [(GetModulesResponse), Integer, Hash[String, String]]
 
           # Gets a list of basic information about the bots of multiple LINE Official Accounts that have attached module channels.
@@ -71,8 +71,8 @@ module Line
           # @param limit Specify the maximum number of bots that you get basic information from. The default value is 100. Max value: 100 
           # @see https://developers.line.biz/en/reference/partner-docs/#get-multiple-bot-info-api
           def get_modules: (
-            start: String?, 
-            limit: Integer?
+            ?start: String?, 
+            ?limit: Integer?
           ) -> (GetModulesResponse)
 
           # To return the initiative (Chat Control) of Active Channel to Primary Channel, call the Release Control API. 

--- a/sig/line/bot/v2/module_attach/api/line_module_attach_client.rbs
+++ b/sig/line/bot/v2/module_attach/api/line_module_attach_client.rbs
@@ -37,13 +37,13 @@ module Line
             grant_type: String, 
             code: String, 
             redirect_uri: String, 
-            code_verifier: String?, 
-            client_id: String?, 
-            client_secret: String?, 
-            region: String?, 
-            basic_search_id: String?, 
-            scope: String?, 
-            brand_type: String?
+            ?code_verifier: String?, 
+            ?client_id: String?, 
+            ?client_secret: String?, 
+            ?region: String?, 
+            ?basic_search_id: String?, 
+            ?scope: String?, 
+            ?brand_type: String?
           ) -> [(AttachModuleResponse), Integer, Hash[String, String]]
 
           # Attach by operation of the module channel provider
@@ -63,13 +63,13 @@ module Line
             grant_type: String, 
             code: String, 
             redirect_uri: String, 
-            code_verifier: String?, 
-            client_id: String?, 
-            client_secret: String?, 
-            region: String?, 
-            basic_search_id: String?, 
-            scope: String?, 
-            brand_type: String?
+            ?code_verifier: String?, 
+            ?client_id: String?, 
+            ?client_secret: String?, 
+            ?region: String?, 
+            ?basic_search_id: String?, 
+            ?scope: String?, 
+            ?brand_type: String?
           ) -> (AttachModuleResponse)
         end
       end


### PR DESCRIPTION
This resolves current inconsistency between implementation and RBS in Client#<request> like below
```
lib/line/bot/v2/messaging_api/api/messaging_api_client.rb:62:12: [error] The method parameter has different kind from the declaration `(broadcast_request: ::Line::Bot::V2::MessagingApi::BroadcastRequest, x_line_retry_key: (::String | nil)) -> [(::String | nil | ::Line::Bot::V2::MessagingApi::ErrorResponse), ::Integer, ::Hash[::String, ::String]]`
│ Diagnostic ID: Ruby::DifferentMethodParameterKind
│
└             x_line_retry_key: nil
              ~~~~~~~~~~~~~~~~~~~~~
...
```

(one of tasks for https://github.com/line/line-bot-sdk-ruby/issues/526)