### PR TITLE
Write actual dependency to line-bot-api.gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,21 +1,18 @@
 source 'https://rubygems.org'
 
+# Write actual dependencies for library to line-bot-api.gemspec
 gemspec
 
-gem 'multipart-post', '~> 2.4.1', require: false
-gem 'net-http', '~> 0.6.0', require: false
-
 group :development, :test do
-  # ref: http://docs.rubocop.org/en/latest/installation/
-  gem 'rack', '~> 3.0'
   gem 'rbs', '~> 3.9.2'
   gem 'rubocop', '~> 1.75.0', require: false
   gem 'steep', '~> 1.10.0'
-  gem 'webrick', '~> 1.9.1'
   gem 'yard', '~> 0.9.20'
 end
 
 group :test do
+  gem 'addressable', '~> 2.3' # TODO: Delete it after cleaning up V1 code
+  gem 'rake', '~> 13.0'
   gem 'rspec', '~> 3.13.0'
   gem 'webmock', '~> 3.25.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,8 @@ PATH
   remote: .
   specs:
     line-bot-api (0.0.1.pre.test)
-      multipart-post (~> 2.4.1)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
 
 GEM
   remote: https://rubygems.org/
@@ -27,15 +28,15 @@ GEM
     benchmark (0.4.0)
     bigdecimal (3.1.9)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+    connection_pool (2.5.1)
     crack (1.0.0)
       bigdecimal
       rexml
-    csv (3.3.3)
-    diff-lcs (1.5.1)
+    csv (3.3.4)
+    diff-lcs (1.6.1)
     drb (2.2.1)
-    ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86_64-linux-gnu)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
     fileutils (1.7.3)
     hashdiff (1.1.2)
     i18n (1.14.7)
@@ -50,16 +51,13 @@ GEM
     minitest (5.25.5)
     multipart-post (2.4.1)
     mutex_m (0.3.0)
-    net-http (0.6.0)
-      uri
-    parallel (1.26.3)
-    parser (3.3.7.4)
+    parallel (1.27.0)
+    parser (3.3.8.0)
       ast (~> 2.4.1)
       racc
     prism (1.4.0)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (3.1.13)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)
@@ -73,7 +71,7 @@ GEM
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
       rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.2)
+    rspec-core (3.13.3)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
@@ -93,7 +91,7 @@ GEM
       rubocop-ast (>= 1.44.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.44.0)
+    rubocop-ast (1.44.1)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
     ruby-progressbar (1.13.0)
@@ -115,7 +113,7 @@ GEM
       strscan (>= 1.0.0)
       terminal-table (>= 2, < 5)
       uri (>= 0.12.0)
-    strscan (3.1.2)
+    strscan (3.1.3)
     terminal-table (4.0.0)
       unicode-display_width (>= 1.1.1, < 4)
     tzinfo (2.0.6)
@@ -128,7 +126,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.1)
     yard (0.9.37)
 
 PLATFORMS
@@ -139,16 +136,12 @@ PLATFORMS
 DEPENDENCIES
   addressable (~> 2.3)
   line-bot-api!
-  multipart-post (~> 2.4.1)
-  net-http (~> 0.6.0)
-  rack (~> 3.0)
   rake (~> 13.0)
   rbs (~> 3.9.2)
   rspec (~> 3.13.0)
   rubocop (~> 1.75.0)
   steep (~> 1.10.0)
   webmock (~> 3.25.0)
-  webrick (~> 1.9.1)
   yard (~> 0.9.20)
 
 BUNDLED WITH

--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -24,10 +24,8 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.2.0'
 
-  spec.add_dependency "multipart-post", "~> 2.4.1"
+  spec.add_runtime_dependency "multipart-post", "~> 2.4"
 
-  spec.add_development_dependency "addressable", "~> 2.3"
-  spec.add_development_dependency 'rake', "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "webmock", "~> 3.8"
+  # gems that aren't default gems as of Ruby 3.4
+  spec.add_runtime_dependency "base64", "~> 0.2"
 end

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -6,7 +6,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: addressable
@@ -14,7 +14,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: ast
@@ -22,7 +22,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -30,7 +30,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: benchmark
@@ -42,19 +42,15 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: cgi
-  version: '0'
-  source:
-    type: stdlib
 - name: concurrent-ruby
   version: '1.1'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: connection_pool
@@ -62,7 +58,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: csv
@@ -70,7 +66,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: date
@@ -82,7 +78,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: digest
@@ -94,7 +90,7 @@ gems:
   source:
     type: stdlib
 - name: ffi
-  version: 1.17.1
+  version: 1.17.2
   source:
     type: rubygems
 - name: fileutils
@@ -110,7 +106,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: i18n
@@ -118,7 +114,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: json
@@ -130,7 +126,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: logger
@@ -142,7 +138,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: monitor
@@ -174,27 +170,19 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: pathname
   version: '0'
   source:
     type: stdlib
-- name: rack
-  version: '2.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: rainbow
   version: '3.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rake
@@ -202,7 +190,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: rbs
@@ -237,10 +225,6 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: tempfile
-  version: '0'
-  source:
-    type: stdlib
 - name: time
   version: '0'
   source:
@@ -258,7 +242,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: uri
@@ -270,19 +254,15 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: webrick
-  version: 1.9.1
-  source:
-    type: rubygems
 - name: yard
   version: '0.9'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 2813b6be44d7617d5defa2aaecdbd4540ee1c418
+    revision: eb6867fdb70e82e3aac6b51623ed1b6760c3c072
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock


### PR DESCRIPTION
In the `*.gemspec` file, we need to list the files the library depends on, specifying at least the minimum versions. Additionally, bundled gems excluded from the standard Ruby install should be explicitly listed, such as `base64`.
- https://github.com/ruby/ruby/blob/93afcfcde36581e6f94b69c3f40fd0021f382d70/gems/bundled_gems
- https://github.com/ruby/ruby/blob/6962f3dc29702ffa68f33d889bab7067b6fe0ca7/lib/bundled_gems.rb#L3-L28

Development dependencies can be written in either the `*.gemspec` or the `Gemfile`. it may be ok to write them in `Gemfile` as of now.