### PR TITLE
Try to support Ruby 3.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -17,6 +17,7 @@ jobs:
         ruby:
           - '3.2'
           - '3.3'
+          - '3.4'
     name: Ruby v${{ matrix.ruby }}
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
(Depends on https://github.com/line/line-bot-sdk-ruby/pull/531 - it adds base64 to runtime dependency (it's excluded from ruby 3.4). See the PR in detail )
Resolve https://github.com/line/line-bot-sdk-ruby/issues/359