### PR TITLE
Modify type for internal http client v2 to follow actual behavior

### DIFF
--- a/lib/line/bot/v2/http_client.rb
+++ b/lib/line/bot/v2/http_client.rb
@@ -20,7 +20,7 @@ module Line
         # NOTE: line-bot-sdk-ruby users should not use this. Breaking changes may occur, so use at your own risk.
         def initialize(base_url:, http_headers: {}, http_options: {})
           @base_url = base_url
-          @http_headers = { 'User-Agent' => "LINE-BotSDK-Ruby/#{Line::Bot::VERSION}" }.merge(normalize_headers(headers: http_headers))
+          @http_headers = { 'User-Agent': "LINE-BotSDK-Ruby/#{Line::Bot::VERSION}" }.merge(normalize_headers(headers: http_headers))
           @http_options = http_options
         end
 
@@ -156,7 +156,7 @@ module Line
           return {} if headers.nil?
 
           headers
-            .transform_keys(&:to_s)
+            .transform_keys(&:to_sym)
             .transform_values(&:to_s)
         end
       end

--- a/sig/line/bot/v2/http_client.rbs
+++ b/sig/line/bot/v2/http_client.rbs
@@ -3,7 +3,7 @@ module Line
     module V2
       class HttpClient
         @base_url: String
-        @http_headers: Hash[String, String]
+        @http_headers: Hash[Symbol, String]
         @http_options: Hash[String | Symbol, untyped]
 
         def initialize: (
@@ -14,49 +14,49 @@ module Line
 
         def get: (
             path: String,
-            ?query_params: Hash[String, untyped]?,
-            ?headers: Hash[String | Symbol, untyped]?
+            ?query_params: Hash[Symbol, untyped]?,
+            ?headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPResponse
 
         def post: (
             path: String,
-            ?query_params: Hash[String, untyped]?,
-            ?body_params: (File | Hash[untyped, untyped])?,
-            ?headers: Hash[String | Symbol, untyped]?
+            ?query_params: Hash[Symbol, untyped]?,
+            ?body_params: (File | Hash[untyped, untyped] | untyped)?,
+            ?headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPResponse
 
         def put: (
             path: String,
-            ?query_params: Hash[String, untyped]?,
-            ?body_params: (File | Hash[untyped, untyped])?,
-            ?headers: Hash[String | Symbol, untyped]?
+            ?query_params: Hash[Symbol, untyped]?,
+            ?body_params: (File | Hash[untyped, untyped] | untyped)?,
+            ?headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPResponse
 
         def delete: (
             path: String,
-            ?query_params: Hash[String, untyped]?,
-            ?headers: Hash[String | Symbol, untyped]?
+            ?query_params: Hash[Symbol, untyped]?,
+            ?headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPResponse
 
         def post_form: (
             path: String,
-            ?query_params: Hash[String, untyped]?,
+            ?query_params: Hash[Symbol, untyped]?,
             ?form_params: Hash[untyped, untyped]?,
-            ?headers: Hash[String | Symbol, untyped]?
+            ?headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPResponse
 
         def post_form_multipart: (
             path: String,
-            ?query_params: Hash[String, untyped]?,
+            ?query_params: Hash[Symbol, untyped]?,
             ?form_params: Hash[untyped, untyped]?,
-            ?headers: Hash[String | Symbol, untyped]?
+            ?headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPResponse
 
         def put_form_multipart: (
             path: String,
-            ?query_params: Hash[String, untyped]?,
+            ?query_params: Hash[Symbol, untyped]?,
             ?form_params: Hash[untyped, untyped]?,
-            ?headers: Hash[String | Symbol, untyped]?
+            ?headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPResponse
 
         private
@@ -64,35 +64,35 @@ module Line
         def build_request: (
             http_class: untyped,
             path: String,
-            query_params: Hash[String, untyped]?,
-            headers: Hash[String | Symbol, untyped]?,
-            ?body_params: (File | Hash[untyped, untyped])?
+            query_params: Hash[Symbol, untyped]?,
+            headers: Hash[Symbol, untyped]?,
+            ?body_params: (File | Hash[untyped, untyped] | untyped)?
           ) -> Net::HTTPRequest
 
         def build_form_request: (
             http_class: untyped,
             path: String,
-            query_params: Hash[String, untyped]?,
+            query_params: Hash[Symbol, untyped]?,
             form_params: Hash[untyped, untyped]?,
-            headers: Hash[String | Symbol, untyped]?
+            headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPRequest
 
         def build_multipart_request: (
             http_class: untyped,
             path: String,
-            query_params: Hash[String, untyped]?,
+            query_params: Hash[Symbol, untyped]?,
             form_params: Hash[untyped, untyped]?,
-            headers: Hash[String | Symbol, untyped]?
+            headers: Hash[Symbol, untyped]?
           ) -> Net::HTTPRequest
 
         def build_url: (
             path: String,
-            query_params: Hash[String, untyped]?
+            query_params: Hash[Symbol, untyped]?
           ) -> URI
 
         def build_headers: (
-            headers: Hash[String | Symbol, untyped]?
-          ) -> Hash[String, String]
+            ?headers: Hash[Symbol, untyped]?
+          ) -> Hash[Symbol, String]
 
         def perform_request: (
             request: Net::HTTPRequest
@@ -104,7 +104,7 @@ module Line
 
         def normalize_headers: (
             headers: Hash[String | Symbol, untyped]?
-          ) -> Hash[String, String]
+          ) -> Hash[Symbol, String]
       end
     end
   end


### PR DESCRIPTION
After using RBS runtime tests, we found that some type adjustments are needed. This change only fixes the internal HTTP client.