### PR TITLE
Use same env for channel access token between app and README

### DIFF
--- a/examples/v1/echobot/README.md
+++ b/examples/v1/echobot/README.md
@@ -6,7 +6,7 @@ An example LINE bot just to echo messages
 
 ```ruby
 $ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
-$ export LINE_CHANNEL_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+$ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```

--- a/examples/v1/echobot/app.rb
+++ b/examples/v1/echobot/app.rb
@@ -4,7 +4,7 @@ require 'line/bot'  # gem 'line-bot-api'
 def client
   @client ||= Line::Bot::Client.new { |config|
     config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-    config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    config.channel_token = ENV["LINE_CHANNEL_ACCESS_TOKEN"]
   }
 end
 

--- a/examples/v1/kitchensink/README.md
+++ b/examples/v1/kitchensink/README.md
@@ -6,7 +6,7 @@ A kitchen-sink LINE bot example
 
 ```ruby
 $ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
-$ export LINE_CHANNEL_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+$ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```

--- a/examples/v1/kitchensink/app.rb
+++ b/examples/v1/kitchensink/app.rb
@@ -11,7 +11,7 @@ def client
   @client ||= Line::Bot::Client.new do |config|
     config.channel_id = ENV["LINE_CHANNEL_ID"]
     config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-    config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+    config.channel_token = ENV["LINE_CHANNEL_ACCESS_TOKEN"]
     config.http_options = {
       open_timeout: 5,
       read_timeout: 5,

--- a/examples/v1/rich_menu/README.md
+++ b/examples/v1/rich_menu/README.md
@@ -6,7 +6,7 @@
 
 ```ruby
 $ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
-$ export LINE_CHANNEL_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+$ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```

--- a/examples/v1/rich_menu/app.rb
+++ b/examples/v1/rich_menu/app.rb
@@ -3,7 +3,7 @@ require 'line-bot-api'
 def client
     @client ||= Line::Bot::Client.new { |config|
       config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
-      config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+      config.channel_token = ENV["LINE_CHANNEL_ACCESS_TOKEN"]
     }
 end
 

--- a/examples/v2/echobot/README.md
+++ b/examples/v2/echobot/README.md
@@ -4,7 +4,7 @@ An example LINE bot just to echo messages
 ## Getting started
 ```ruby
 $ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
-$ export LINE_CHANNEL_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+$ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```

--- a/examples/v2/kitchensink/README.md
+++ b/examples/v2/kitchensink/README.md
@@ -6,7 +6,7 @@ A kitchen-sink LINE bot example
 
 ```ruby
 $ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
-$ export LINE_CHANNEL_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+$ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```

--- a/examples/v2/rich_menu/README.md
+++ b/examples/v2/rich_menu/README.md
@@ -6,7 +6,7 @@
 
 ```ruby
 $ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
-$ export LINE_CHANNEL_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
+$ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```


### PR DESCRIPTION
`LINE_CHANNEL_ACCESS_TOKEN` is used in app, so README should use same one.
and more, this change unifies env name.