### PR TITLE
Fail if key uses underscore

### DIFF
--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -574,9 +574,9 @@ describe 'misc' do
             "messages" => [
               {
                 "type" => "textV2",
-                "text" => " Hello, world! {name} san!",
+                "text" => " Hello, world! {user_name} san!",
                 "substitution" => {
-                  "name" => {
+                  "user_name" => {
                     "type" => "mention",
                     "mentionee" => {
                       "type" => "user",
@@ -595,9 +595,9 @@ describe 'misc' do
         to: 'USER_ID',
         messages: [
           Line::Bot::V2::MessagingApi::TextMessageV2.new(
-            text: ' Hello, world! {name} san!',
+            text: 'Hello, world! {user_name} san!',
             substitution: {
-              "name": Line::Bot::V2::MessagingApi::MentionSubstitutionObject.new(
+              "user_name": Line::Bot::V2::MessagingApi::MentionSubstitutionObject.new(
                 mentionee: Line::Bot::V2::MessagingApi::UserMentionTarget.new(
                   user_id: 'U1234567890'
                 )


### PR DESCRIPTION
(to reproduce issue)
`user_name` is converted `userName` unintentionally.