### PR TITLE
Update version only in v1

### DIFF
--- a/lib/line/bot/v1/api/version.rb
+++ b/lib/line/bot/v1/api/version.rb
@@ -17,7 +17,7 @@ module Line
     module API
       # @deprecated
       # Use {Line::Bot::VERSION} instead.
-      VERSION = "1.29.0"
+      VERSION = "1.30.0-deprecated"
     end
   end
 end


### PR DESCRIPTION
Next, version 1.30.0 will be released. [lib/line/bot/version.rb will be updated by github actions](https://github.com/line/line-bot-sdk-ruby/blob/46e6fcffd3548de5d3d96d688a603d4f9c5d0f60/.github/workflows/publish.yml#L28-L36), but lib/line/bot/v1/api/version.rb will not. Since this file is planned to be removed in the following release, it will be updated manually rather than automated.