### PR TITLE
Fix unnecessary camelize issue

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,8 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/lib/line/bot/v2/utils.rb
+++ b/lib/line/bot/v2/utils.rb
@@ -2,6 +2,12 @@ module Line
   module Bot
     module V2
       module Utils
+        # NOTE: Although it should be set in the request class side,
+        #       it can only be set here because requests in Hash are also permitted.
+        #       If there is a mix of camelize and non-camelize cases even with the same key name,
+        #       breaking change that does not allow Hash requests will be necessary.
+        NO_CAMELIZE_PARENT_KEYS = %w(substitution).freeze
+
         # NOTE: line-bot-sdk-ruby users should not use this. Breaking changes may occur, so use at your own risk.
         def self.deep_underscore(hash)
           hash.each_with_object({}) do |(key, value), result| # steep:ignore UnannotatedEmptyCollection
@@ -57,12 +63,16 @@ module Line
             object.map { |item| deep_camelize(item) }
           when Hash
             object.each_with_object({}) do |(k, v), new_object| # steep:ignore UnannotatedEmptyCollection
-              camel_key = camelize(k)
-              next if camel_key.nil?
-
-              camel_key = camel_key.to_sym
-              new_value = v.is_a?(Array) || v.is_a?(Hash) ? deep_camelize(v) : v
-              new_object[camel_key] = new_value
+              if NO_CAMELIZE_PARENT_KEYS.include?(k.to_s)
+                new_object[k.to_sym] = if v.is_a?(Hash)
+                                         v.transform_keys(&:to_sym).transform_values { deep_camelize(_1) }
+                                       else
+                                         v
+                                       end
+              else
+                camel_key = camelize(k)&.to_sym
+                new_object[camel_key] = v.is_a?(Array) || v.is_a?(Hash) ? deep_camelize(v) : v if camel_key
+              end
             end
           else
             object

--- a/sig/line/bot/v2/utils.rbs
+++ b/sig/line/bot/v2/utils.rbs
@@ -2,6 +2,8 @@ module Line
   module Bot
     module V2
       module Utils
+        NO_CAMELIZE_PARENT_KEYS: Array[String]
+
         def self.deep_underscore: (Hash[untyped, untyped]) -> Hash[Symbol, untyped]
 
         def self.deep_symbolize: (untyped) -> untyped

--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -574,9 +574,9 @@ describe 'misc' do
             "messages" => [
               {
                 "type" => "textV2",
-                "text" => " Hello, world! {name} san!",
+                "text" => " Hello, world! {user_name} san!",
                 "substitution" => {
-                  "name" => {
+                  "user_name" => {
                     "type" => "mention",
                     "mentionee" => {
                       "type" => "user",
@@ -595,9 +595,9 @@ describe 'misc' do
         to: 'USER_ID',
         messages: [
           Line::Bot::V2::MessagingApi::TextMessageV2.new(
-            text: ' Hello, world! {name} san!',
+            text: ' Hello, world! {user_name} san!',
             substitution: {
-              "name": Line::Bot::V2::MessagingApi::MentionSubstitutionObject.new(
+              user_name: Line::Bot::V2::MessagingApi::MentionSubstitutionObject.new(
                 mentionee: Line::Bot::V2::MessagingApi::UserMentionTarget.new(
                   user_id: 'U1234567890'
                 )

--- a/spec/line/bot/v2/utils_spec.rb
+++ b/spec/line/bot/v2/utils_spec.rb
@@ -121,6 +121,40 @@ describe Line::Bot::V2::Utils do
       expected_output = { key: ['array', 'of', 'values'] }
       expect(Line::Bot::V2::Utils.deep_camelize(input)).to eq(expected_output)
     end
+
+    it "doesn't modify no_camelize_parent_keys children" do
+      stub_const("Line::Bot::V2::Utils::NO_CAMELIZE_PARENT_KEYS", %w(substitution))
+
+      input = {
+        type: "textV2",
+        text: "Hello, world! {user_name} san!",
+        substitution: { # This key should not be camelized
+          user_name: {
+            type: "mention",
+            mentionee: {
+              type: "user",
+              "user_id": "U1234567890abcdef1234567890abcdef"
+            }
+          }
+        }
+      }
+
+      expected_output = {
+        type: "textV2",
+        text: "Hello, world! {user_name} san!",
+        substitution: {
+          user_name: {
+            type: "mention",
+            mentionee: {
+              type: "user",
+              "userId": "U1234567890abcdef1234567890abcdef" # Only this key should be camelized
+            }
+          }
+        }
+      }
+
+      expect(Line::Bot::V2::Utils.deep_camelize(input)).to eq(expected_output)
+    end
   end
 
   describe '.deep_compact' do


### PR DESCRIPTION
fix #562

This solves the problem of camelizing API fields that should not be camelized.
In short, when using `TextV2` messages, the user can specify their own key in the `substituion`, but the bug occurs when snake_case is used there.

This should be set in the request class side, but since request body specification by hash without request class is also accepted, we have to deal with this workaround.

This is fine for now because there is only `substitution`, but if a pattern caramelizes and does not caramelize the same key name in the future, a major modification or breaking change may be necessary.