### PR TITLE
Add explanations of requests with Hash / JSON

### DIFF
--- a/README_v2.md
+++ b/README_v2.md
@@ -41,6 +41,9 @@ gem install line-bot-api
 ```
 
 ## Synopsis
+### RBS
+This library provides [RBS](https://github.com/ruby/rbs) files for type checking.\
+You can code with type support in the corresponding IDE or editor.
 
 ### Basic Usage
 
@@ -178,12 +181,109 @@ end
 main
 ```
 
+### Use with Hash / JSON
+You can use Hash instead of the SDK classes.
+So you can also use Hash parsed from JSON as a parameter.
+
+This is useful, for example, in migrating from v1 or building Flex Message.
+
+**But this is not recommended because you lose type checking by RBS.**
+
+```ruby
+client = Line::Bot::V2::MessagingApi::ApiClient.new(
+  channel_access_token: ENV.fetch("LINE_CHANNEL_ACCESS_TOKEN"),
+)
+
+request =  {
+  to: "U4af4980629...",
+  messages: [
+    {
+      type: "flex",
+      alt_text: "This is a Flex Message",
+      contents: {
+        type: "bubble",
+        body: {
+          type: "box",
+          layout: "horizontal",
+          contents: [
+            {
+              type: "text",
+              text: "Hello"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+client.push_message(push_message_request: request)
+
+# or
+
+request = JSON.parse(
+  <<~JSON
+    {
+      "to": "U4af4980629...",
+      "messages": [
+        {
+          "type": "flex",
+          "alt_text": "This is a Flex Message",
+          "contents": {
+            "type": "bubble",
+            "body": {
+              "type": "box",
+              "layout": "horizontal",
+              "contents": [
+                {
+                  "type": "text",
+                  "text": "Hello"
+                }
+              ]
+            }
+          }
+        }
+      ]
+    }
+  JSON
+)
+client.push_message(push_message_request: request)
+```
+
+#### Convert to SDK classes
+You can convert Hash / JSON to SDK classes using `#create` method.
+
+```ruby
+json = <<~JSON
+  {
+    "to": "U4af4980629...",
+    "messages": [
+      {
+        "type": "flex",
+        "alt_text": "This is a Flex Message",
+        "contents": {
+          "type": "bubble",
+          "body": {
+            "type": "box",
+            "layout": "horizontal",
+            "contents": [
+              {
+                "type": "text",
+                "text": "Hello"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+JSON
+request = Line::Bot::V2::MessagingApi::PushMessageRequest.create(
+  JSON.parse(json)
+)
+```
+
 ### More examples
 See the [examples](examples/v2) directory for more examples.
-
-### RBS
-This library provides [RBS](https://github.com/ruby/rbs) files for type checking.\
-You can code with type support in the corresponding IDE or editor.
 
 ## Media
 News: https://developers.line.biz/en/news/

--- a/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-generator/model.pebble
@@ -108,11 +108,12 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::{{ packageName | camelize }}::{{ model.model.classname }}] Instance of the class
           def self.create(args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
             {%- if model.model.vendorExtensions.get("x-children") != null and model.model.vendorExtensions.get("x-discriminator-property") != null %}
-            klass = detect_class(type: args[:{{ model.model.vendorExtensions.get("x-discriminator-property") }}])
-            return klass.new(**args) if klass # steep:ignore
+            klass = detect_class(type: symbolized_args[:{{ model.model.vendorExtensions.get("x-discriminator-property") }}])
+            return klass.new(**symbolized_args) if klass # steep:ignore
             {%- endif %}
-            return new(**args) # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/channel_access_token_key_ids_response.rb
@@ -43,7 +43,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ChannelAccessToken::ChannelAccessTokenKeyIdsResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/channel_access_token/model/error_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/error_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ChannelAccessToken::ErrorResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_channel_access_token_response.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ChannelAccessToken::IssueChannelAccessTokenResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_short_lived_channel_access_token_response.rb
@@ -55,7 +55,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ChannelAccessToken::IssueShortLivedChannelAccessTokenResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/issue_stateless_channel_access_token_response.rb
@@ -55,7 +55,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ChannelAccessToken::IssueStatelessChannelAccessTokenResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rb
+++ b/lib/line/bot/v2/channel_access_token/model/verify_channel_access_token_response.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ChannelAccessToken::VerifyChannelAccessTokenResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/age_tile.rb
+++ b/lib/line/bot/v2/insight/model/age_tile.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::AgeTile] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/app_type_tile.rb
+++ b/lib/line/bot/v2/insight/model/app_type_tile.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::AppTypeTile] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/area_tile.rb
+++ b/lib/line/bot/v2/insight/model/area_tile.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::AreaTile] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/error_detail.rb
+++ b/lib/line/bot/v2/insight/model/error_detail.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::ErrorDetail] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/error_response.rb
+++ b/lib/line/bot/v2/insight/model/error_response.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::ErrorResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/gender_tile.rb
+++ b/lib/line/bot/v2/insight/model/gender_tile.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GenderTile] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_friends_demographics_response.rb
+++ b/lib/line/bot/v2/insight/model/get_friends_demographics_response.rb
@@ -103,7 +103,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetFriendsDemographicsResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_message_event_response.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response.rb
@@ -67,7 +67,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetMessageEventResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_message_event_response_click.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_click.rb
@@ -65,7 +65,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetMessageEventResponseClick] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_message_event_response_message.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_message.rb
@@ -107,7 +107,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetMessageEventResponseMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_message_event_response_overview.rb
+++ b/lib/line/bot/v2/insight/model/get_message_event_response_overview.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetMessageEventResponseOverview] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_number_of_followers_response.rb
+++ b/lib/line/bot/v2/insight/model/get_number_of_followers_response.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetNumberOfFollowersResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rb
+++ b/lib/line/bot/v2/insight/model/get_number_of_message_deliveries_response.rb
@@ -103,7 +103,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetNumberOfMessageDeliveriesResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response.rb
@@ -67,7 +67,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetStatisticsPerUnitResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_click.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetStatisticsPerUnitResponseClick] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_message.rb
@@ -114,7 +114,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetStatisticsPerUnitResponseMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rb
+++ b/lib/line/bot/v2/insight/model/get_statistics_per_unit_response_overview.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::GetStatisticsPerUnitResponseOverview] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/insight/model/subscription_period_tile.rb
+++ b/lib/line/bot/v2/insight/model/subscription_period_tile.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Insight::SubscriptionPeriodTile] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/add_liff_app_request.rb
+++ b/lib/line/bot/v2/liff/model/add_liff_app_request.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::AddLiffAppRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/add_liff_app_response.rb
+++ b/lib/line/bot/v2/liff/model/add_liff_app_response.rb
@@ -41,7 +41,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::AddLiffAppResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/get_all_liff_apps_response.rb
+++ b/lib/line/bot/v2/liff/model/get_all_liff_apps_response.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::GetAllLiffAppsResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/liff_app.rb
+++ b/lib/line/bot/v2/liff/model/liff_app.rb
@@ -77,7 +77,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::LiffApp] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/liff_features.rb
+++ b/lib/line/bot/v2/liff/model/liff_features.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::LiffFeatures] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/liff_view.rb
+++ b/lib/line/bot/v2/liff/model/liff_view.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::LiffView] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/update_liff_app_request.rb
+++ b/lib/line/bot/v2/liff/model/update_liff_app_request.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::UpdateLiffAppRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/liff/model/update_liff_view.rb
+++ b/lib/line/bot/v2/liff/model/update_liff_view.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Liff::UpdateLiffView] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/adaccount.rb
+++ b/lib/line/bot/v2/manage_audience/model/adaccount.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::Adaccount] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/add_audience_to_audience_group_request.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::AddAudienceToAudienceGroupRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/audience.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::Audience] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/audience_group.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group.rb
@@ -108,7 +108,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::AudienceGroup] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/audience_group_job.rb
+++ b/lib/line/bot/v2/manage_audience/model/audience_group_job.rb
@@ -85,7 +85,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::AudienceGroupJob] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/create_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_audience_group_request.rb
@@ -67,7 +67,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::CreateAudienceGroupRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/create_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_audience_group_response.rb
@@ -85,7 +85,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::CreateAudienceGroupResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_request.rb
@@ -55,7 +55,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::CreateClickBasedAudienceGroupRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_click_based_audience_group_response.rb
@@ -97,7 +97,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::CreateClickBasedAudienceGroupResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_request.rb
@@ -49,7 +49,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::CreateImpBasedAudienceGroupRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/create_imp_based_audience_group_response.rb
@@ -67,7 +67,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::CreateImpBasedAudienceGroupResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/detailed_owner.rb
+++ b/lib/line/bot/v2/manage_audience/model/detailed_owner.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::DetailedOwner] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/error_detail.rb
+++ b/lib/line/bot/v2/manage_audience/model/error_detail.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::ErrorDetail] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/error_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/error_response.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::ErrorResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/get_audience_data_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_audience_data_response.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::GetAudienceDataResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/get_audience_groups_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_audience_groups_response.rb
@@ -79,7 +79,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::GetAudienceGroupsResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_shared_audience_data_response.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::GetSharedAudienceDataResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/get_shared_audience_groups_response.rb
+++ b/lib/line/bot/v2/manage_audience/model/get_shared_audience_groups_response.rb
@@ -79,7 +79,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::GetSharedAudienceGroupsResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/manage_audience/model/update_audience_group_description_request.rb
+++ b/lib/line/bot/v2/manage_audience/model/update_audience_group_description_request.rb
@@ -43,7 +43,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ManageAudience::UpdateAudienceGroupDescriptionRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/action.rb
+++ b/lib/line/bot/v2/messaging_api/model/action.rb
@@ -49,9 +49,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Action] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/age_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/age_demographic_filter.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::AgeDemographicFilter] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/all_mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/all_mention_target.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::AllMentionTarget] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/alt_uri.rb
+++ b/lib/line/bot/v2/messaging_api/model/alt_uri.rb
@@ -41,7 +41,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::AltUri] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/app_type_demographic_filter.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::AppTypeDemographicFilter] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/area_demographic_filter.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::AreaDemographicFilter] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/audience_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/audience_recipient.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::AudienceRecipient] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/audio_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/audio_message.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::AudioMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/bot_info_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/bot_info_response.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::BotInfoResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/broadcast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/broadcast_request.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::BroadcastRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/buttons_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/buttons_template.rb
@@ -95,7 +95,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ButtonsTemplate] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/camera_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/camera_action.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::CameraAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/camera_roll_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/camera_roll_action.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::CameraRollAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/carousel_column.rb
+++ b/lib/line/bot/v2/messaging_api/model/carousel_column.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::CarouselColumn] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/carousel_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/carousel_template.rb
@@ -65,7 +65,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::CarouselTemplate] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/chat_reference.rb
+++ b/lib/line/bot/v2/messaging_api/model/chat_reference.rb
@@ -43,7 +43,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ChatReference] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/clipboard_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/clipboard_action.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ClipboardAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/clipboard_imagemap_action.rb
@@ -60,7 +60,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ClipboardImagemapAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/confirm_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/confirm_template.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ConfirmTemplate] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/create_rich_menu_alias_request.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::CreateRichMenuAliasRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/datetime_picker_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/datetime_picker_action.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::DatetimePickerAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/demographic_filter.rb
@@ -42,9 +42,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::DemographicFilter] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/emoji.rb
+++ b/lib/line/bot/v2/messaging_api/model/emoji.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Emoji] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/emoji_substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/emoji_substitution_object.rb
@@ -55,7 +55,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::EmojiSubstitutionObject] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/error_detail.rb
+++ b/lib/line/bot/v2/messaging_api/model/error_detail.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ErrorDetail] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/error_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/error_response.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ErrorResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/filter.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Filter] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_block_style.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_block_style.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexBlockStyle] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_box.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box.rb
@@ -209,7 +209,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexBox] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_box_background.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_background.rb
@@ -41,9 +41,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexBoxBackground] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_box_linear_gradient.rb
@@ -71,7 +71,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexBoxLinearGradient] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_bubble.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_bubble.rb
@@ -89,7 +89,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexBubble] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_bubble_styles.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_bubble_styles.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexBubbleStyles] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_button.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_button.rb
@@ -125,7 +125,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexButton] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_carousel.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_carousel.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexCarousel] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_component.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_component.rb
@@ -41,9 +41,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexComponent] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_container.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_container.rb
@@ -41,9 +41,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexContainer] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_filler.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_filler.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexFiller] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_icon.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_icon.rb
@@ -102,7 +102,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexIcon] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_image.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_image.rb
@@ -138,7 +138,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexImage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_message.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_separator.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_separator.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexSeparator] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_span.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_span.rb
@@ -77,7 +77,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexSpan] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_text.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_text.rb
@@ -179,7 +179,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexText] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/flex_video.rb
+++ b/lib/line/bot/v2/messaging_api/model/flex_video.rb
@@ -71,7 +71,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::FlexVideo] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/gender_demographic_filter.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GenderDemographicFilter] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_name_list_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GetAggregationUnitNameListResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_aggregation_unit_usage_response.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GetAggregationUnitUsageResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_followers_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GetFollowersResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_joined_membership_users_response.rb
@@ -49,7 +49,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GetJoinedMembershipUsersResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/get_membership_subscription_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_membership_subscription_response.rb
@@ -49,7 +49,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GetMembershipSubscriptionResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_message_content_transcoding_response.rb
@@ -43,7 +43,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GetMessageContentTranscodingResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/get_webhook_endpoint_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GetWebhookEndpointResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/group_member_count_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_member_count_response.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GroupMemberCountResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/group_summary_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_summary_response.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GroupSummaryResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/group_user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/group_user_profile_response.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::GroupUserProfileResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/image_carousel_column.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_carousel_column.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImageCarouselColumn] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/image_carousel_template.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_carousel_template.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImageCarouselTemplate] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/image_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/image_message.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImageMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_action.rb
@@ -48,9 +48,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImagemapAction] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/imagemap_area.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_area.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImagemapArea] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/imagemap_base_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_base_size.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImagemapBaseSize] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/imagemap_external_link.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_external_link.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImagemapExternalLink] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/imagemap_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_message.rb
@@ -90,7 +90,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImagemapMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/imagemap_video.rb
+++ b/lib/line/bot/v2/messaging_api/model/imagemap_video.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ImagemapVideo] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/issue_link_token_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/issue_link_token_response.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::IssueLinkTokenResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/limit.rb
+++ b/lib/line/bot/v2/messaging_api/model/limit.rb
@@ -49,7 +49,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Limit] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/location_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/location_action.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::LocationAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/location_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/location_message.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::LocationMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/mark_messages_as_read_request.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MarkMessagesAsReadRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/members_ids_response.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MembersIdsResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/membership.rb
+++ b/lib/line/bot/v2/messaging_api/model/membership.rb
@@ -95,7 +95,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Membership] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/membership_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/membership_list_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MembershipListResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/mention_substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/mention_substitution_object.rb
@@ -49,7 +49,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MentionSubstitutionObject] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/mention_target.rb
@@ -41,9 +41,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MentionTarget] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/message.rb
+++ b/lib/line/bot/v2/messaging_api/model/message.rb
@@ -54,9 +54,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Message] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/message_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_action.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MessageAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/message_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_imagemap_action.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MessageImagemapAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/message_quota_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/message_quota_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MessageQuotaResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/multicast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/multicast_request.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::MulticastRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/narrowcast_progress_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/narrowcast_progress_response.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::NarrowcastProgressResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/narrowcast_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/narrowcast_request.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::NarrowcastRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/number_of_messages_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/number_of_messages_response.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::NumberOfMessagesResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/operator_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/operator_demographic_filter.rb
@@ -71,7 +71,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::OperatorDemographicFilter] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/operator_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/operator_recipient.rb
@@ -71,7 +71,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::OperatorRecipient] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/pnp_messages_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/pnp_messages_request.rb
@@ -60,7 +60,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::PnpMessagesRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/postback_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/postback_action.rb
@@ -77,7 +77,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::PostbackAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/push_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/push_message_request.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::PushMessageRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/push_message_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/push_message_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::PushMessageResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/quick_reply.rb
+++ b/lib/line/bot/v2/messaging_api/model/quick_reply.rb
@@ -49,7 +49,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::QuickReply] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/quick_reply_item.rb
+++ b/lib/line/bot/v2/messaging_api/model/quick_reply_item.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::QuickReplyItem] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/quota_consumption_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/quota_consumption_response.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::QuotaConsumptionResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/recipient.rb
@@ -42,9 +42,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Recipient] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/redelivery_recipient.rb
+++ b/lib/line/bot/v2/messaging_api/model/redelivery_recipient.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RedeliveryRecipient] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/reply_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/reply_message_request.rb
@@ -60,7 +60,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ReplyMessageRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/reply_message_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/reply_message_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ReplyMessageResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_alias_list_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuAliasListResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_alias_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_alias_response.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuAliasResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_area.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_area.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuArea] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_link_operation.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBatchLinkOperation] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_operation.rb
@@ -43,9 +43,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBatchOperation] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_progress_response.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBatchProgressResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_request.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBatchRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_all_operation.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBatchUnlinkAllOperation] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_batch_unlink_operation.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBatchUnlinkOperation] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bounds.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bounds.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBounds] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_link_request.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBulkLinkRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_bulk_unlink_request.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuBulkUnlinkRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_id_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_id_response.rb
@@ -41,7 +41,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuIdResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_list_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_list_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuListResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_request.rb
@@ -71,7 +71,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_response.rb
@@ -77,7 +77,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_size.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_size.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuSize] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/rich_menu_switch_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/rich_menu_switch_action.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RichMenuSwitchAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/room_member_count_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/room_member_count_response.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RoomMemberCountResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/room_user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/room_user_profile_response.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::RoomUserProfileResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/sender.rb
+++ b/lib/line/bot/v2/messaging_api/model/sender.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Sender] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/sent_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/sent_message.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::SentMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/set_webhook_endpoint_request.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::SetWebhookEndpointRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/show_loading_animation_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/show_loading_animation_request.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ShowLoadingAnimationRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/sticker_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/sticker_message.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::StickerMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscribed_membership_plan.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::SubscribedMembershipPlan] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/subscribed_membership_user.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscribed_membership_user.rb
@@ -60,7 +60,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::SubscribedMembershipUser] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/subscription.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Subscription] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rb
+++ b/lib/line/bot/v2/messaging_api/model/subscription_period_demographic_filter.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::SubscriptionPeriodDemographicFilter] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/substitution_object.rb
+++ b/lib/line/bot/v2/messaging_api/model/substitution_object.rb
@@ -42,9 +42,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::SubstitutionObject] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/template.rb
+++ b/lib/line/bot/v2/messaging_api/model/template.rb
@@ -41,9 +41,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::Template] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/template_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/template_message.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::TemplateMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_request.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::TestWebhookEndpointRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/test_webhook_endpoint_response.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::TestWebhookEndpointResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/text_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/text_message.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::TextMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/text_message_v2.rb
+++ b/lib/line/bot/v2/messaging_api/model/text_message_v2.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::TextMessageV2] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/update_rich_menu_alias_request.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::UpdateRichMenuAliasRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/uri_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/uri_action.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::URIAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/uri_imagemap_action.rb
+++ b/lib/line/bot/v2/messaging_api/model/uri_imagemap_action.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::URIImagemapAction] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/user_mention_target.rb
+++ b/lib/line/bot/v2/messaging_api/model/user_mention_target.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::UserMentionTarget] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/user_profile_response.rb
+++ b/lib/line/bot/v2/messaging_api/model/user_profile_response.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::UserProfileResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/validate_message_request.rb
+++ b/lib/line/bot/v2/messaging_api/model/validate_message_request.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::ValidateMessageRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/messaging_api/model/video_message.rb
+++ b/lib/line/bot/v2/messaging_api/model/video_message.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::MessagingApi::VideoMessage] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/module/model/acquire_chat_control_request.rb
+++ b/lib/line/bot/v2/module/model/acquire_chat_control_request.rb
@@ -49,7 +49,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Module::AcquireChatControlRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/module/model/detach_module_request.rb
+++ b/lib/line/bot/v2/module/model/detach_module_request.rb
@@ -43,7 +43,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Module::DetachModuleRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/module/model/get_modules_response.rb
+++ b/lib/line/bot/v2/module/model/get_modules_response.rb
@@ -55,7 +55,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Module::GetModulesResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/module/model/module_bot.rb
+++ b/lib/line/bot/v2/module/model/module_bot.rb
@@ -67,7 +67,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Module::ModuleBot] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/module_attach/model/attach_module_response.rb
+++ b/lib/line/bot/v2/module_attach/model/attach_module_response.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::ModuleAttach::AttachModuleResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/shop/model/error_response.rb
+++ b/lib/line/bot/v2/shop/model/error_response.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Shop::ErrorResponse] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/shop/model/mission_sticker_request.rb
+++ b/lib/line/bot/v2/shop/model/mission_sticker_request.rb
@@ -61,7 +61,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Shop::MissionStickerRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/account_link_event.rb
+++ b/lib/line/bot/v2/webhook/model/account_link_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::AccountLinkEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/action_result.rb
+++ b/lib/line/bot/v2/webhook/model/action_result.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ActionResult] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/activated_event.rb
+++ b/lib/line/bot/v2/webhook/model/activated_event.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ActivatedEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/all_mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/all_mentionee.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::AllMentionee] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/attached_module_content.rb
+++ b/lib/line/bot/v2/webhook/model/attached_module_content.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::AttachedModuleContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/audio_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/audio_message_content.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::AudioMessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/beacon_content.rb
+++ b/lib/line/bot/v2/webhook/model/beacon_content.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::BeaconContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/beacon_event.rb
+++ b/lib/line/bot/v2/webhook/model/beacon_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::BeaconEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/bot_resumed_event.rb
+++ b/lib/line/bot/v2/webhook/model/bot_resumed_event.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::BotResumedEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/bot_suspended_event.rb
+++ b/lib/line/bot/v2/webhook/model/bot_suspended_event.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::BotSuspendedEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/callback_request.rb
+++ b/lib/line/bot/v2/webhook/model/callback_request.rb
@@ -55,7 +55,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::CallbackRequest] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/chat_control.rb
+++ b/lib/line/bot/v2/webhook/model/chat_control.rb
@@ -41,7 +41,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ChatControl] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/content_provider.rb
+++ b/lib/line/bot/v2/webhook/model/content_provider.rb
@@ -54,7 +54,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ContentProvider] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/deactivated_event.rb
+++ b/lib/line/bot/v2/webhook/model/deactivated_event.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::DeactivatedEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/delivery_context.rb
+++ b/lib/line/bot/v2/webhook/model/delivery_context.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::DeliveryContext] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/detached_module_content.rb
+++ b/lib/line/bot/v2/webhook/model/detached_module_content.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::DetachedModuleContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/emoji.rb
+++ b/lib/line/bot/v2/webhook/model/emoji.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::Emoji] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/event.rb
+++ b/lib/line/bot/v2/webhook/model/event.rb
@@ -72,9 +72,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::Event] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/file_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/file_message_content.rb
@@ -59,7 +59,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::FileMessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/follow_detail.rb
+++ b/lib/line/bot/v2/webhook/model/follow_detail.rb
@@ -41,7 +41,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::FollowDetail] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/follow_event.rb
+++ b/lib/line/bot/v2/webhook/model/follow_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::FollowEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/group_source.rb
+++ b/lib/line/bot/v2/webhook/model/group_source.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::GroupSource] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/image_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/image_message_content.rb
@@ -65,7 +65,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ImageMessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/image_set.rb
+++ b/lib/line/bot/v2/webhook/model/image_set.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ImageSet] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/join_event.rb
+++ b/lib/line/bot/v2/webhook/model/join_event.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::JoinEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/joined_members.rb
+++ b/lib/line/bot/v2/webhook/model/joined_members.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::JoinedMembers] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/joined_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/joined_membership_content.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::JoinedMembershipContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/leave_event.rb
+++ b/lib/line/bot/v2/webhook/model/leave_event.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::LeaveEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/left_members.rb
+++ b/lib/line/bot/v2/webhook/model/left_members.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::LeftMembers] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/left_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/left_membership_content.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::LeftMembershipContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/link_content.rb
+++ b/lib/line/bot/v2/webhook/model/link_content.rb
@@ -48,7 +48,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::LinkContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/link_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/link_things_content.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::LinkThingsContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/location_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/location_message_content.rb
@@ -71,7 +71,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::LocationMessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/member_joined_event.rb
+++ b/lib/line/bot/v2/webhook/model/member_joined_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::MemberJoinedEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/member_left_event.rb
+++ b/lib/line/bot/v2/webhook/model/member_left_event.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::MemberLeftEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/membership_content.rb
@@ -42,9 +42,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::MembershipContent] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/membership_event.rb
+++ b/lib/line/bot/v2/webhook/model/membership_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::MembershipEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/mention.rb
+++ b/lib/line/bot/v2/webhook/model/mention.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::Mention] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/mentionee.rb
@@ -54,9 +54,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::Mentionee] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/message_content.rb
+++ b/lib/line/bot/v2/webhook/model/message_content.rb
@@ -48,9 +48,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::MessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/message_event.rb
+++ b/lib/line/bot/v2/webhook/model/message_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::MessageEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/module_content.rb
+++ b/lib/line/bot/v2/webhook/model/module_content.rb
@@ -41,9 +41,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ModuleContent] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/module_event.rb
+++ b/lib/line/bot/v2/webhook/model/module_event.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ModuleEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/pnp_delivery.rb
+++ b/lib/line/bot/v2/webhook/model/pnp_delivery.rb
@@ -42,7 +42,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::PnpDelivery] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/pnp_delivery_completion_event.rb
+++ b/lib/line/bot/v2/webhook/model/pnp_delivery_completion_event.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::PnpDeliveryCompletionEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/postback_content.rb
+++ b/lib/line/bot/v2/webhook/model/postback_content.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::PostbackContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/postback_event.rb
+++ b/lib/line/bot/v2/webhook/model/postback_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::PostbackEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/renewed_membership_content.rb
+++ b/lib/line/bot/v2/webhook/model/renewed_membership_content.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::RenewedMembershipContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/room_source.rb
+++ b/lib/line/bot/v2/webhook/model/room_source.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::RoomSource] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/scenario_result.rb
+++ b/lib/line/bot/v2/webhook/model/scenario_result.rb
@@ -90,7 +90,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ScenarioResult] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/scenario_result_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/scenario_result_things_content.rb
@@ -53,7 +53,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ScenarioResultThingsContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/source.rb
+++ b/lib/line/bot/v2/webhook/model/source.rb
@@ -43,9 +43,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::Source] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/sticker_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/sticker_message_content.rb
@@ -90,7 +90,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::StickerMessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/text_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/text_message_content.rb
@@ -83,7 +83,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::TextMessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/things_content.rb
+++ b/lib/line/bot/v2/webhook/model/things_content.rb
@@ -41,9 +41,10 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ThingsContent] Instance of the class
           def self.create(args) # steep:ignore
-            klass = detect_class(type: args[:type])
-            return klass.new(**args) if klass # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            klass = detect_class(type: symbolized_args[:type])
+            return klass.new(**symbolized_args) if klass # steep:ignore
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/things_event.rb
+++ b/lib/line/bot/v2/webhook/model/things_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::ThingsEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/unfollow_event.rb
+++ b/lib/line/bot/v2/webhook/model/unfollow_event.rb
@@ -72,7 +72,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::UnfollowEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/unlink_things_content.rb
+++ b/lib/line/bot/v2/webhook/model/unlink_things_content.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::UnlinkThingsContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/unsend_detail.rb
+++ b/lib/line/bot/v2/webhook/model/unsend_detail.rb
@@ -41,7 +41,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::UnsendDetail] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/unsend_event.rb
+++ b/lib/line/bot/v2/webhook/model/unsend_event.rb
@@ -78,7 +78,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::UnsendEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/user_mentionee.rb
+++ b/lib/line/bot/v2/webhook/model/user_mentionee.rb
@@ -66,7 +66,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::UserMentionee] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/user_source.rb
+++ b/lib/line/bot/v2/webhook/model/user_source.rb
@@ -47,7 +47,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::UserSource] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/video_message_content.rb
+++ b/lib/line/bot/v2/webhook/model/video_message_content.rb
@@ -65,7 +65,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::VideoMessageContent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/video_play_complete.rb
+++ b/lib/line/bot/v2/webhook/model/video_play_complete.rb
@@ -41,7 +41,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::VideoPlayComplete] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/lib/line/bot/v2/webhook/model/video_play_complete_event.rb
+++ b/lib/line/bot/v2/webhook/model/video_play_complete_event.rb
@@ -84,7 +84,8 @@ module Line
           # @param args [Hash] Hash containing all the required attributes
           # @return [Line::Bot::V2::Webhook::VideoPlayCompleteEvent] Instance of the class
           def self.create(args) # steep:ignore
-            return new(**args) # steep:ignore
+            symbolized_args = Line::Bot::V2::Utils.deep_symbolize(args)
+            return new(**symbolized_args) # steep:ignore
           end
 
           # @param other [Object] Object to compare

--- a/spec/line/bot/v2/messaging_api/model/flex_container_spec.rb
+++ b/spec/line/bot/v2/messaging_api/model/flex_container_spec.rb
@@ -1,0 +1,112 @@
+require 'spec_helper'
+
+describe 'Line::Bot::V2::MessagingApi::FlexContainer' do
+  describe '#create' do
+    context 'with parsed JSON string' do
+      let(:original_json_string) do
+        <<~JSON
+          {
+            "type": "bubble",
+            "body": {
+              "type": "box",
+              "layout": "horizontal",
+              "contents": [
+                {
+                  "type": "text",
+                  "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+                  "wrap": true,
+                  "color": "#ff0000",
+                  "flex": 2
+                },
+                {
+                  "type": "text",
+                  "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+                }
+              ]
+            },
+            "footer": {
+              "type": "box",
+              "layout": "horizontal",
+              "contents": [
+                {
+                  "type": "image",
+                  "url": "https://example.com/flex/images/image.jpg",
+                  "animated": true,
+                  "size": "xs",
+                  "action": {
+                    "type": "uri",
+                    "uri": "https://example.com"
+                  }
+                },
+                {
+                  "type": "image",
+                  "url": "https://example.com/flex/images/image.jpg",
+                  "animated": true,
+                  "size": "xs"
+                }
+              ]
+            }
+          }
+        JSON
+      end
+
+      let(:container_instance) do
+        Line::Bot::V2::MessagingApi::FlexContainer.create(JSON.parse(original_json_string))
+      end
+
+      it 'creates a valid Line::Bot::V2::MessagingAPI::FlexContainer' do
+        expect(container_instance).to be_a(Line::Bot::V2::MessagingApi::FlexContainer)
+
+        expect(container_instance.class).to eq(Line::Bot::V2::MessagingApi::FlexBubble)
+        expect(container_instance.type).to eq('bubble')
+        expect(container_instance.body).to be_a(Line::Bot::V2::MessagingApi::FlexBox)
+        expect(container_instance.body.type).to eq('box')
+        expect(container_instance.body.layout).to eq('horizontal')
+        expect(container_instance.body.contents).to be_a(Array)
+        expect(container_instance.body.contents.size).to eq(2)
+
+        expect(container_instance.body.contents[0]).to be_a(Line::Bot::V2::MessagingApi::FlexText)
+        expect(container_instance.body.contents[0].text).to eq('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
+        expect(container_instance.body.contents[0].wrap).to eq(true)
+        expect(container_instance.body.contents[0].color).to eq('#ff0000')
+        expect(container_instance.body.contents[0].flex).to eq(2)
+
+        expect(container_instance.body.contents[1]).to be_a(Line::Bot::V2::MessagingApi::FlexText)
+        expect(container_instance.body.contents[1].text).to eq('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.')
+        expect(container_instance.body.contents[1].wrap).to be_nil
+        expect(container_instance.body.contents[1].color).to be_nil
+        expect(container_instance.body.contents[1].flex).to be_nil
+
+        expect(container_instance.footer).to be_a(Line::Bot::V2::MessagingApi::FlexBox)
+        expect(container_instance.footer.type).to eq('box')
+        expect(container_instance.footer.layout).to eq('horizontal')
+        expect(container_instance.footer.contents).to be_a(Array)
+        expect(container_instance.footer.contents.size).to eq(2)
+
+        expect(container_instance.footer.contents[0]).to be_a(Line::Bot::V2::MessagingApi::FlexImage)
+        expect(container_instance.footer.contents[0].url).to eq('https://example.com/flex/images/image.jpg')
+        expect(container_instance.footer.contents[0].animated).to eq(true)
+        expect(container_instance.footer.contents[0].size).to eq('xs')
+        expect(container_instance.footer.contents[0].action).to be_a(Line::Bot::V2::MessagingApi::URIAction)
+        expect(container_instance.footer.contents[0].action.type).to eq('uri')
+        expect(container_instance.footer.contents[0].action.uri).to eq('https://example.com')
+
+        expect(container_instance.footer.contents[1]).to be_a(Line::Bot::V2::MessagingApi::FlexImage)
+        expect(container_instance.footer.contents[1].url).to eq('https://example.com/flex/images/image.jpg')
+        expect(container_instance.footer.contents[1].animated).to eq(true)
+        expect(container_instance.footer.contents[1].size).to eq('xs')
+        expect(container_instance.footer.contents[1].action).to be_nil
+      end
+
+      it 'represents the same JSON contents' do
+        json_string_from_instance = Line::Bot::V2::Utils.deep_compact(
+          Line::Bot::V2::Utils.deep_camelize(
+            Line::Bot::V2::Utils.deep_to_hash(container_instance)
+          )
+        ).to_json
+
+        expect(JSON.parse(json_string_from_instance)).to eq(JSON.parse(original_json_string)) # ignore order
+      end
+    end
+  end
+end

--- a/spec/line/bot/v2/misc_spec.rb
+++ b/spec/line/bot/v2/misc_spec.rb
@@ -696,6 +696,76 @@ describe 'misc' do
       expect(body.sent_messages[0].quote_token).to eq('IStG5h1Tz7b...')
     end
 
+    it 'request - success - flex message using request class from JSON' do
+      stub_request(:post, "https://api.line.me/v2/bot/message/push")
+        .with(
+          headers: {
+            'Authorization' => "Bearer test-channel-access-token"
+          },
+          body:  {
+            to: "U4af4980629...",
+            messages: [
+              {
+                type: "flex",
+                altText: "This is a Flex Message",
+                contents: {
+                  type: "bubble",
+                  body: {
+                    type: "box",
+                    layout: "horizontal",
+                    contents: [
+                      {
+                        type: "text",
+                        text: "Hello"
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            notificationDisabled: false
+          }.to_json
+        )
+        .to_return(status: response_code, body: response_body, headers: { 'Content-Type' => 'application/json' })
+
+      request = Line::Bot::V2::MessagingApi::PushMessageRequest.create(
+        JSON.parse(
+          <<~JSON
+            {
+              "to": "U4af4980629...",
+              "messages": [
+                {
+                  "type": "flex",
+                  "alt_text": "This is a Flex Message",
+                  "contents": {
+                    "type": "bubble",
+                    "body": {
+                      "type": "box",
+                      "layout": "horizontal",
+                      "contents": [
+                        {
+                          "type": "text",
+                          "text": "Hello"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }
+          JSON
+        )
+      )
+      body, status_code, headers = client.push_message_with_http_info(push_message_request: request)
+
+      expect(status_code).to eq(200)
+      expect(body).to be_a(Line::Bot::V2::MessagingApi::PushMessageResponse)
+      expect(body.sent_messages).to be_a(Array)
+      expect(body.sent_messages[0]).to be_a(Line::Bot::V2::MessagingApi::SentMessage)
+      expect(body.sent_messages[0].id).to eq('461230966842064897')
+      expect(body.sent_messages[0].quote_token).to eq('IStG5h1Tz7b...')
+    end
+
     it 'requees with custom aggregation unit that contains underscore' do
       stub_request(:post, "https://api.line.me/v2/bot/message/push")
         .with(


### PR DESCRIPTION
Added explanation to README for `Hash` requests, which were implicitly allowed. f5bf047f7c40585b08953f143fe3496db2356f9b
Also, updated model class to allow JSON parsed Hash to be used in requests. 8de74314c22904319a06603a551e9f13c2bf2f54 [b81fa5d](https://github.com/line/line-bot-sdk-ruby/pull/568/commits/b81fa5da1140ed8701a54ec8f3a2fbab978b0593)

We hope this will make it easier to build and use Flex Messages from JSON.

related to https://github.com/line/line-bot-sdk-ruby/issues/533, https://github.com/line/line-bot-sdk-ruby/issues/365
> json to flex