### PR TITLE
Add an example of narrowcast

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -77,6 +77,8 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
 

--- a/examples/v2/kitchensink/app.rb
+++ b/examples/v2/kitchensink/app.rb
@@ -910,6 +910,57 @@ def handle_message_event(event)
 
       reply_text(event, "[STATS]\n#{stats}")
 
+    when 'narrowcast'
+      request = Line::Bot::V2::MessagingApi::NarrowcastRequest.new(
+        messages: [
+          Line::Bot::V2::MessagingApi::TextMessage.new(text: 'Hello, this is a narrowcast message')
+        ],
+        filter: Line::Bot::V2::MessagingApi::Filter.new(
+          demographic: Line::Bot::V2::MessagingApi::OperatorDemographicFilter.new(
+            _or: [
+              Line::Bot::V2::MessagingApi::OperatorDemographicFilter.new(
+                _and: [
+                  Line::Bot::V2::MessagingApi::AgeDemographicFilter.new(
+                    gte: 'age_20',
+                    lte: 'age_60'
+                  ),
+                  Line::Bot::V2::MessagingApi::AppTypeDemographicFilter.new(
+                    one_of: ['ios']
+                  )
+                ]
+              ),
+              Line::Bot::V2::MessagingApi::OperatorDemographicFilter.new(
+                _and: [
+                  Line::Bot::V2::MessagingApi::GenderDemographicFilter.new(
+                    one_of: ['female']
+                  ),
+                  Line::Bot::V2::MessagingApi::AreaDemographicFilter.new(
+                    one_of: %w(jp_08 jp_09 jp_10 jp_11 jp_12 jp_13 jp_14)
+                  ),
+                ]
+              )
+            ]
+          )
+        )
+      )
+      _body, _status_code, headers = client.narrowcast_with_http_info(narrowcast_request: request)
+      request_id = headers['x-line-request-id']
+
+      reply_text(event, "Narrowcast requested, requestId: #{request_id}")
+
+      client.show_loading_animation(show_loading_animation_request: Line::Bot::V2::MessagingApi::ShowLoadingAnimationRequest.new(
+        chat_id: event.source.user_id
+      ))
+      sleep 5
+
+      response = client.get_narrowcast_progress(request_id: request_id)
+      client.push_message(push_message_request: Line::Bot::V2::MessagingApi::PushMessageRequest.new(
+        to: event.source.user_id,
+        messages: [
+          Line::Bot::V2::MessagingApi::TextMessage.new(text: "Narrowcast status: #{response}")
+        ]
+      ))
+
     else
       if (event.message.quoted_message_id != nil) 
         reply_text(event, "[ECHO]\n#{event.message.text} Thanks you for quoting my message!")

--- a/lib/line/bot/v2/utils.rb
+++ b/lib/line/bot/v2/utils.rb
@@ -38,13 +38,26 @@ module Line
           if object.is_a?(Array)
             object.map { |item| deep_to_hash(item) }
           elsif object.is_a?(Hash)
-            object.transform_keys(&:to_sym).transform_values { |v| deep_to_hash(v) }
+            result = object.transform_keys do |k|
+              if k.to_s.start_with?('_') && Line::Bot::V2::RESERVED_WORDS.include?(k.to_s.delete_prefix('_').to_sym)
+                k.to_s.delete_prefix('_').to_sym
+              else
+                k.to_sym
+              end
+            end
+            result.transform_values { |v| deep_to_hash(v) }
           elsif object.instance_variables.empty?
             object
           else
             object.instance_variables.each_with_object({}) do |var, hash| # steep:ignore UnannotatedEmptyCollection
               value = object.instance_variable_get(var)
-              key = var.to_s.delete('@').to_sym
+
+              key = var.to_s.delete('@')
+              if key.start_with?('_') && Line::Bot::V2::RESERVED_WORDS.include?(key.delete_prefix('_').to_sym)
+                key = key.delete_prefix('_')
+              end
+              key = key.to_sym
+
               hash[key] = deep_to_hash(value)
             end
           end

--- a/spec/line/bot/v2/utils_spec.rb
+++ b/spec/line/bot/v2/utils_spec.rb
@@ -89,6 +89,12 @@ describe Line::Bot::V2::Utils do
       expected_output = [{ name: 'Alice' }, { name: 'Bob' }]
       expect(Line::Bot::V2::Utils.deep_to_hash(input)).to eq(expected_output)
     end
+
+    it 'fixes reserved words' do
+      input = { '_and' => 123, '___FILE__' => 'example', '_hoge': 123 }
+      expected_output = { and: 123, __FILE__: 'example', _hoge: 123 }
+      expect(Line::Bot::V2::Utils.deep_to_hash(input)).to eq(expected_output)
+    end
   end
 
   describe '.deep_camelize' do


### PR DESCRIPTION
related to #533 
> narrowcast

Fixed a bug that caused the API to request with the replacement of reserved Ruby characters like `_and` 7eca519145c878cddef3f3ce5c6225b6853d8d67