### PR TITLE
Fix bundler mode to deployment at publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: 3.3
-      - run: bundle install
+      - run: bundle install --deployment
       - name: Update version file with the release version
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then


### PR DESCRIPTION
fix https://github.com/line/line-bot-sdk-ruby/issues/581

https://github.com/line/line-bot-sdk-ruby/pull/580 was not sufficient.

If there is a difference between the installed gems and `Gemfile.lock`, an error occurs when publishing.
Therefore, we need to set `deployment` mode so that `bundle install` is performed with the contents of `Gemfile.lock`. 