### PR TITLE
Update version of Gemfile.lock in publish workflow automatically

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,6 @@ jobs:
         with:
           bundler-cache: true
           ruby-version: 3.3
-      - run: bundle install --deployment
       - name: Update version file with the release version
         run: |
           if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,7 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
           sed -i "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" lib/line/bot/version.rb
+          sed -i "s/line-bot-api (.*)/line-bot-api ($VERSION)/" Gemfile.lock
           
           cat lib/line/bot/version.rb
           
@@ -43,7 +44,7 @@ jobs:
           git config user.name github-actions
           git config user.email github-actions@github.com
 
-          git add lib/line/bot/version.rb
+          git add lib/line/bot/version.rb Gemfile.lock
           git commit -m "Set version to $VERSION"
       - uses: rubygems/release-gem@a25424ba2ba8b387abc8ef40807c2c85b96cbe32 # v1.1.1
 


### PR DESCRIPTION
fix #583 

Sorry for repeating myself.

Fix #582 was a misunderstanding, when dynamically rewriting the version, only gemspec versioned up the `line-bot-api` gem, but left the `Gemfile.lock` unchanged, causing the version mismatch.