### PR TITLE
Deploy docs on release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
         required: true
 
 jobs:
-  push:
+  release-package:
     name: Push gem to RubyGems.org
     runs-on: ubuntu-latest
 
@@ -64,3 +64,12 @@ jobs:
               body: issueBody,
               assignees
             });
+
+  deploy-docs:
+    needs: [release-package]
+    permissions:
+      contents: read
+      pages: write
+      issues: write
+      id-token: write
+    uses: ./.github/workflows/deploy-doc.yml


### PR DESCRIPTION
It seems it worked as expected. Let's update document too on release.
- https://line.github.io/line-bot-sdk-ruby/
- https://line.github.io/line-bot-sdk-ruby/_index.html


related to: https://github.com/line/line-bot-sdk-ruby/pull/588

