### PR TITLE
Replace old url with new url, show client urls

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,2 +1,3 @@
 -
 *.md
+LICENSE

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ You may use this classes to use LINE Messaging API features.
 
 #### Webhook
 - [Line::Bot::V2::WebhookParser](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/WebhookParser.html)  ([LINE Developers](https://developers.line.biz/en/reference/messaging-api/#webhooks))
+- [Line::Bot::V2::Event](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/Webhook/Event.html) ([LINE Developers](https://developers.line.biz/en/reference/messaging-api/#webhook-event-objects))
 
 ### Clients
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ See the official API documentation for more information
 
 Also, generated documentation by YARD is available.
 
-- https://rubydoc.info/gems/line-bot-api
+- https://line.github.io/line-bot-sdk-ruby/
+- https://line.github.io/line-bot-sdk-ruby/_index.html
 
 ## Requirements
 This library requires Ruby 3.2 or later.
@@ -115,6 +116,27 @@ post '/callback' do
   "OK"
 end
 ```
+
+### Main classes
+You may use this classes to use LINE Messaging API features.
+
+#### Webhook
+- [Line::Bot::V2::WebhookParser](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/WebhookParser.html)  ([LINE Developers](https://developers.line.biz/en/reference/messaging-api/#webhooks))
+
+### Clients
+
+| Class(YARD documentation)                                                                                                              | API EndPoint                                      | LINE Developers                                                                                                    |
+|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------|--------------------------------------------------------------------------------------------------------------------|
+| [Line::Bot::V2::ChannelAccessToken::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/ChannelAccessToken/ApiClient.html) | https://api.line.me/** (related to oauth)         | https://developers.line.biz/en/reference/messaging-api/#channel-access-token                                       |
+| [Line::Bot::V2::Insight::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/Insight/ApiClient.html)                       | https://api.line.me/v2/bot/insight/**             | https://developers.line.biz/en/reference/messaging-api/#get-insight                                                |
+| [Line::Bot::V2::Liff::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/Liff/ApiClient.html)                             | https://api.line.me/liff/**                       | https://developers.line.biz/en/reference/liff-server/#server-api                                                   |
+| [Line::Bot::V2::ManageAudience::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/ManageAudience/ApiClient.html)         | https://api.line.me/v2/bot/audienceGroup/**       | https://developers.line.biz/en/reference/messaging-api/#manage-audience-group                                      |
+| [Line::Bot::V2::ManageAudience::ApiBlobClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/ManageAudience/ApiBlobClient.html) | https://api-data.line.me/v2/bot/audienceGroup/**  | https://developers.line.biz/en/reference/messaging-api/#manage-audience-group                                      |
+| [Line::Bot::V2::MessagingApi::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/MessagingApi/ApiClient.html)             | https://api.line.me/v2/bot/**                     | https://developers.line.biz/en/reference/messaging-api/<br/>https://developers.line.biz/en/reference/partner-docs/ |
+| [Line::Bot::V2::MessagingApi::ApiBlobClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/MessagingApi/ApiBlobClient.html)     | https://api-data.line.me/v2/bot/**                | https://developers.line.biz/en/reference/messaging-api/                                                            |
+| [Line::Bot::V2::Module::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/Module/ApiClient.html)                         | https://api.line.me/v2/bot/** (related to module) | https://developers.line.biz/en/reference/partner-docs/#module                                                      |
+| [Line::Bot::V2::ModuleAttach::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/ModuleAttach/ApiClient.html)             | https://manager.line.biz/module/auth/v1/token/**  | https://developers.line.biz/en/reference/partner-docs/#module                                                      |
+| [Line::Bot::V2::Shop::ApiClient](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/Shop/ApiClient.html)                             | https://api.line.me/shop/**                       | https://developers.line.biz/en/reference/partner-docs/#mission-stickers                                            |
 
 ### Use HTTP Information
 You may need to store the ```x-line-request-id``` header obtained as a response from several APIs.\
@@ -292,7 +314,7 @@ See https://semver.org/
 
 ### v1 and v2
 v1 and v2 are completely different implementations. Migration to v2 is strongly recommended.
-Please refer to [Migration guide](migration_from_v1_to_v2_guide) for migration procedure.
+Please refer to [Migration guide](migration_from_v1_to_v2_guide.md) for migration procedure.
 
 ## Media
 News: https://developers.line.biz/en/news/

--- a/line-bot-api.gemspec
+++ b/line-bot-api.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.metadata = {
     "bug_tracker_uri" => "#{spec.homepage}/issues",
     "changelog_uri" => "#{spec.homepage}/releases",
-    "documentation_uri" => "https://rubydoc.info/gems/#{spec.name}/#{spec.version}",
+    "documentation_uri" => "https://line.github.io/line-bot-sdk-ruby/",
     "homepage_uri" => spec.homepage,
     "source_code_uri" => spec.homepage,
   }


### PR DESCRIPTION
This change updates the document URL and introduces multiple clients in the README.

The document has switched to using GitHub Pages, moving from https://rubydoc.info/gems/line-bot-api to https://line.github.io/line-bot-sdk-ruby/.

Additionally, since finding the various clients without any explanation can be challenging, an introduction has been added in the README. There's no absolute need to add this to the migration guide, as the correct link to v2 code is already provided in the comments of v1 code.

related to: https://github.com/line/line-bot-sdk-ruby/pull/588