### PR TITLE
Move up example link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Or install it yourself as:
 gem install line-bot-api
 ```
 
+## Example projects
+We provide examples to help you get started with the SDK.
+They work in your local environment if you have owned your bot account.
+
+Go the [examples](examples/v2) directory for more examples.
+
 ## Synopsis
 ### RBS
 This library provides [RBS](https://github.com/ruby/rbs) files for type checking.\
@@ -304,9 +310,6 @@ request = Line::Bot::V2::MessagingApi::PushMessageRequest.create(
   JSON.parse(json)
 )
 ```
-
-### More examples
-See the [examples](examples/v2) directory for more examples.
 
 ## Versioning
 This project respects semantic versioning.


### PR DESCRIPTION
In general, links higher up are viewed more than those lower down, as not all sections are necessarily read. Since many examples work with copy & paste, This change modifies the position of the introduction in the README to emphasize this. It's a very minor change.