### PR TITLE
Fix namespaces in migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ You may use this classes to use LINE Messaging API features.
 
 #### Webhook
 - [Line::Bot::V2::WebhookParser](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/WebhookParser.html)  ([LINE Developers](https://developers.line.biz/en/reference/messaging-api/#webhooks))
-- [Line::Bot::V2::Event](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/Webhook/Event.html) ([LINE Developers](https://developers.line.biz/en/reference/messaging-api/#webhook-event-objects))
+- [Line::Bot::V2::Webhook::Event](https://line.github.io/line-bot-sdk-ruby/Line/Bot/V2/Webhook/Event.html) ([LINE Developers](https://developers.line.biz/en/reference/messaging-api/#webhook-event-objects))
 
 ### Clients
 

--- a/migration_from_v1_to_v2_guide.md
+++ b/migration_from_v1_to_v2_guide.md
@@ -47,7 +47,7 @@ However, it's not recommended to always use it as it could lead to migration err
 ## Clients
 There are several types of API clients.
 Depending on the classification of the API, there are several types of clients.
-- `MassagingAPI`.
+- `MessagingApi`.
 - `ManageAudience`
 - `Inshight`
 - `ChannelAccessToken`
@@ -55,10 +55,10 @@ Depending on the classification of the API, there are several types of clients.
 - `Shop`
   and so on.
 
-In addition, the same `MessagingAPI` is divided into `ApiBlobClient` for APIs that use https://api-data.line.me to upload and download files.
+In addition, the same `MessagingApi` is divided into `ApiBlobClient` for APIs that use https://api-data.line.me to upload and download files.
 
-- `Line::Bot::V2::MessagingAPI::ApiClient`.
-- `Line::Bot::V2::MessagingAPI::ApiBlobClient`.
+- `Line::Bot::V2::MessagingApi::ApiClient`.
+- `Line::Bot::V2::MessagingApi::ApiBlobClient`.
 
 These are planned to be integrated in the future, but this has not yet been accomplished.
 
@@ -92,11 +92,11 @@ client = Line::Bot::V2::MessagingApi::ApiClient.new(
   channel_access_token: ENV.fetch("LINE_CHANNEL_ACCESS_TOKEN")
 )
 
-message = Line::Bot::V2::MessagingAPI::TextMessage.new( # No need to pass `type: "text"`
+message = Line::Bot::V2::MessagingApi::TextMessage.new( # No need to pass `type: "text"`
   text: 'Hello, this is a test message!'
 )
 
-request = Line::Bot::V2::MessagingAPI::PushMessageRequest.new(
+request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
   to: 'U1234567890abcdef1234567890abcdef',
   messages: [
     message
@@ -107,7 +107,7 @@ response, status_code, response_headers = client.push_message_with_http_info(
   push_message_request: request
 )
 
-puts response.class # => Line::Bot::V2::MessagingAPI::PushMessageResponse
+puts response.class # => Line::Bot::V2::MessagingApi::PushMessageResponse
 ```
 #### v2 (with Hash)
 This is not a recommended way.
@@ -120,7 +120,7 @@ client = Line::Bot::V2::MessagingApi::ApiClient.new(
   channel_access_token: ENV.fetch("LINE_CHANNEL_ACCESS_TOKEN")
 )
 
-request = Line::Bot::V2::MessagingAPI::PushMessageRequest.new(
+request = Line::Bot::V2::MessagingApi::PushMessageRequest.new(
   to: 'U1234567890abcdef1234567890abcdef',
   messages: [
     {
@@ -134,7 +134,7 @@ response, status_code, response_headers = client.push_message_with_http_info(
   push_message_request: request
 )
 
-puts response.class # => Line::Bot::V2::MessagingAPI::PushMessageResponse
+puts response.class # => Line::Bot::V2::MessagingApi::PushMessageResponse
 ```
 ### Handling Webhook
 #### v1

--- a/migration_from_v1_to_v2_guide.md
+++ b/migration_from_v1_to_v2_guide.md
@@ -92,11 +92,11 @@ client = Line::Bot::V2::MessagingApi::ApiClient.new(
   channel_access_token: ENV.fetch("LINE_CHANNEL_ACCESS_TOKEN")
 )
 
-message = Line::Bot::V2::TextMessage.new( # No need to pass `type: "text"`
+message = Line::Bot::V2::MessagingAPI::TextMessage.new( # No need to pass `type: "text"`
   text: 'Hello, this is a test message!'
 )
 
-request = Line::Bot::V2::PushMessageRequest.new(
+request = Line::Bot::V2::MessagingAPI::PushMessageRequest.new(
   to: 'U1234567890abcdef1234567890abcdef',
   messages: [
     message
@@ -107,7 +107,7 @@ response, status_code, response_headers = client.push_message_with_http_info(
   push_message_request: request
 )
 
-puts response.class # => Line::Bot::V2::PushMessageResponse
+puts response.class # => Line::Bot::V2::MessagingAPI::PushMessageResponse
 ```
 #### v2 (with Hash)
 This is not a recommended way.
@@ -120,7 +120,7 @@ client = Line::Bot::V2::MessagingApi::ApiClient.new(
   channel_access_token: ENV.fetch("LINE_CHANNEL_ACCESS_TOKEN")
 )
 
-request = Line::Bot::V2::PushMessageRequest.new(
+request = Line::Bot::V2::MessagingAPI::PushMessageRequest.new(
   to: 'U1234567890abcdef1234567890abcdef',
   messages: [
     {
@@ -134,7 +134,7 @@ response, status_code, response_headers = client.push_message_with_http_info(
   push_message_request: request
 )
 
-puts response.class # => Line::Bot::V2::PushMessageResponse
+puts response.class # => Line::Bot::V2::MessagingAPI::PushMessageResponse
 ```
 ### Handling Webhook
 #### v1

--- a/spec/line/bot/v2/messaging_api/model/flex_container_spec.rb
+++ b/spec/line/bot/v2/messaging_api/model/flex_container_spec.rb
@@ -54,7 +54,7 @@ describe 'Line::Bot::V2::MessagingApi::FlexContainer' do
         Line::Bot::V2::MessagingApi::FlexContainer.create(JSON.parse(original_json_string))
       end
 
-      it 'creates a valid Line::Bot::V2::MessagingAPI::FlexContainer' do
+      it 'creates a valid Line::Bot::V2::MessagingApi::FlexContainer' do
         expect(container_instance).to be_a(Line::Bot::V2::MessagingApi::FlexContainer)
 
         expect(container_instance.class).to eq(Line::Bot::V2::MessagingApi::FlexBubble)


### PR DESCRIPTION
Some examples are wrong in migration guide. This change fixes them.

https://github.com/line/line-bot-sdk-ruby/releases/tag/v1.30.0 has been already fixed.

This is detected with this script (https://gist.github.com/Yang-33/57e571ffecd6dd755c2d1445de1abd2d). This is a makeshift script and might detect incorrectly. Since maintenance is not straightforward, I'll avoid adding it as a spec for now.