### PR TITLE
Improve issue triage and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ title: 'Bug Report'
 
  <!--
 ## Before Creating an Issue
-- Please check our [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/messaging-api/) for more information on the Messaging API
+- Please check our [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/tags/messaging-api/) for more information on the Messaging API
 - Make sure the issue you are reporting isn't already addressed in the documentation or existing issues.
 
 ## When Creating an Issue

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,35 +1,40 @@
 ---
 name: Bug Report Template
-about: for Bug Report
+about: Use this template to report bugs in the line-bot-sdk-ruby
 title: 'Bug Report'
-labels: bug
 ---
 
  <!--
-## Do this before creating an issue
- - Check our [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/messaging-api/) page for more information on LINE bots and the Messaging API
- ## When creating an issue
- - Provide detailed information about the issue you had with the SDK as below
+## Before Creating an Issue
+- Please check our [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/messaging-api/) for more information on the Messaging API
+- Make sure the issue you are reporting isn't already addressed in the documentation or existing issues.
+
+## When Creating an Issue
+- Provide detailed information about the issue you experienced with the SDK using the template below.
 -->
 
- ## System Informations
+## System Information
+- Ruby version:
+- line-bot-api gem version:
+- OS (and version):
+- Any other relevant environment details (e.g. Rails version, hosting service, etc.):
 
- * Ruby version:
- * Gem (line-bot-api) version:
- * OS:
+## Expected Behavior
+<!-- Describe what you expected to happen -->
 
- ## Expected Behavior
-<!-- Tell us what should happen -->
+## Current Behavior
+<!-- Describe what actually happened instead of the expected behavior -->
 
- ## Current Behavior
-<!-- Tell us what happens instead of the expected behavior -->
-
- ## Steps to Reproduce
-<!-- Provide a link to a live example, or an unambigeous set of steps to -->
+## Steps to Reproduce
+<!-- Provide a link to a live example or a clear set of steps to reproduce the issue.
+     If possible, provide minimal code (e.g. test code, a draft PR, or a link to a forked repository). -->
 1.
-1.
-1.
-1.
+2.
+3.
 
- ## Logs
-<!-- Provide logs if possible -->
+## Logs
+<!-- If possible, provide logs to help identify the issue -->
+
+## Additional Context (Optional)
+<!-- Add any other context or information that might be relevant to the issue.
+     For example, related issues, potential causes, or possible solutions. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,7 +6,7 @@ title: "Question"
 
 <!--
 ## Before Creating a Question Issue
-- Please check the [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/messaging-api/) for answers to common questions.
+- Please check the [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/tags/messaging-api/) for answers to common questions.
 - Make sure your question hasn't already been asked in other Issues or the documentation.
 
 ## This Is Not
@@ -23,7 +23,7 @@ title: "Question"
 - [ ] [Index Page - line-bot-api gem](https://line.github.io/line-bot-sdk-ruby/_index.html)
 - [ ] [Examples - line-bot-api gem](https://github.com/line/line-bot-sdk-ruby/tree/master/examples/v2)
 - [ ] [Developer Documentation - LINE Developers](https://developers.line.biz/en/docs/)
-- [ ] [FAQ - LINE Developers](https://developers.line.biz/en/faq/messaging-api/)
+- [ ] [FAQ - LINE Developers](https://developers.line.biz/en/faq/tags/messaging-api/)
 
 ## Summary of Your Question
 <!-- Provide a clear and concise description of what you want to know. -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,47 @@
+---
+name: "Question Template"
+about: "Use this template to ask questions about usage or implementation of the line-bot-sdk-ruby."
+title: "Question"
+---
+
+<!--
+## Before Creating a Question Issue
+- Please check the [developer documentation](https://developers.line.biz/en/docs/) and [FAQ](https://developers.line.biz/en/faq/messaging-api/) for answers to common questions.
+- Make sure your question hasn't already been asked in other Issues or the documentation.
+
+## This Is Not
+- A bug report. If you think you've found a bug, please use the "Bug Report" template.
+- A place to request new features. If you have a feature request, consider opening a "Feature Request" issue or PR.
+
+## When Creating a Question
+- Provide detailed information about your environment and context so we can better understand and answer your question.
+- Let us know what you've tried so far (e.g. searching docs, existing issues, etc.).
+-->
+
+## Have You Checked the Following?
+- [ ] [LINE BOT SDK for Ruby Documentation - line-bot-api gem](https://line.github.io/line-bot-sdk-ruby/)
+- [ ] [Index Page - line-bot-api gem](https://line.github.io/line-bot-sdk-ruby/_index.html)
+- [ ] [Examples - line-bot-api gem](https://github.com/line/line-bot-sdk-ruby/tree/master/examples/v2)
+- [ ] [Developer Documentation - LINE Developers](https://developers.line.biz/en/docs/)
+- [ ] [FAQ - LINE Developers](https://developers.line.biz/en/faq/messaging-api/)
+
+## Summary of Your Question
+<!-- Provide a clear and concise description of what you want to know. -->
+
+## Details
+<!-- Provide any code snippets, relevant logs, or background details that will help us understand your question better. -->
+
+## What You've Tried
+<!-- Let us know any steps you've already taken to answer your own question, 
+     such as searching in documentation or checking existing issues. -->
+
+## Your Environment
+<!-- For example:
+- Ruby version:
+- line-bot-api gem version:
+- OS (and version):
+- Any other relevant environment details (e.g. Rails version, hosting service, etc.)
+-->
+
+## Additional Context (Optional)
+<!-- Add any other context, possible considerations, or related links here. -->

--- a/.github/workflows/close-issue.yml
+++ b/.github/workflows/close-issue.yml
@@ -19,7 +19,7 @@ jobs:
           days-before-issue-close: 0
           stale-issue-label: "no-activity"
           close-issue-message: "This issue was closed because it has been inactive for 14 days."
-          exempt-issue-labels: "bug,enhancement,keep"
+          exempt-issue-labels: "bug,enhancement,keep,untriaged"
           days-before-pr-stale: -1
           days-before-pr-close: 14
           stale-pr-label: "no-activity"

--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,0 +1,34 @@
+# https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
+# https://github.com/marketplace/actions/close-stale-issues
+name: Label issue
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - closed
+
+jobs:
+  label-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Add label on issue open
+        if: github.event.action == 'opened' || github.event.action == 'reopened'
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --add-label "untriaged" \
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Remove label on issue close
+        if: github.event.action == 'closed'
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --remove-label "untriaged"
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/label-issue.yml
+++ b/.github/workflows/label-issue.yml
@@ -1,5 +1,3 @@
-# https://docs.github.com/en/actions/managing-issues-and-pull-requests/closing-inactive-issues
-# https://github.com/marketplace/actions/close-stale-issues
 name: Label issue
 
 on:


### PR DESCRIPTION
This change modifies the issue template for bug reports and adds an issue template for inquiries.

Additionally, issues now always have the `untriaged` label set, and they won't be closed until a maintainer removes the label.


## minor tasks
- [x] add `untriaged` label in this repository