### PR TITLE
Ignore unused gems for rbs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.9.4)
+    rbs (3.9.3)
       logger
     regexp_parser (2.10.0)
     rexml (3.4.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rbs (3.9.3)
+    rbs (3.9.4)
       logger
     regexp_parser (2.10.0)
     rexml (3.4.1)

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -1,28 +1,12 @@
 ---
 path: ".gem_rbs_collection"
 gems:
-- name: activesupport
-  version: '7.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: addressable
   version: '2.8'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: ast
-  version: '2.4'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
+    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 - name: base64
@@ -30,78 +14,26 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
+    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: benchmark
-  version: '0'
-  source:
-    type: stdlib
 - name: bigdecimal
   version: '3.1'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
+    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: cgi
-  version: '0'
-  source:
-    type: stdlib
-- name: concurrent-ruby
-  version: '1.1'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: connection_pool
-  version: '2.4'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: csv
-  version: '3.3'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: date
-  version: '0'
-  source:
-    type: stdlib
 - name: diff-lcs
   version: '1.5'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
+    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: digest
-  version: '0'
-  source:
-    type: stdlib
-- name: erb
-  version: '0'
-  source:
-    type: stdlib
-- name: ffi
-  version: 1.17.2
-  source:
-    type: rubygems
 - name: fileutils
-  version: '0'
-  source:
-    type: stdlib
-- name: forwardable
   version: '0'
   source:
     type: stdlib
@@ -110,49 +42,9 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
+    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: i18n
-  version: '1.10'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: json
-  version: '0'
-  source:
-    type: stdlib
-- name: listen
-  version: '3.9'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: logger
-  version: '0'
-  source:
-    type: stdlib
-- name: minitest
-  version: '5.25'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: monitor
-  version: '0'
-  source:
-    type: stdlib
-- name: mutex_m
-  version: 0.3.0
-  source:
-    type: rubygems
 - name: net-http
   version: '0'
   source:
@@ -161,106 +53,18 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: openssl
-  version: '0'
-  source:
-    type: stdlib
-- name: optparse
-  version: '0'
-  source:
-    type: stdlib
-- name: parser
-  version: '3.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: pathname
-  version: '0'
-  source:
-    type: stdlib
-- name: rack
-  version: '2.2'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: rainbow
-  version: '3.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: rake
   version: '13.0'
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
+    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
-- name: rbs
-  version: 3.9.3
-  source:
-    type: rubygems
-- name: rdoc
-  version: '0'
-  source:
-    type: stdlib
-- name: ripper
-  version: '0'
-  source:
-    type: stdlib
-- name: securerandom
-  version: '0'
-  source:
-    type: stdlib
-- name: singleton
-  version: '0'
-  source:
-    type: stdlib
-- name: socket
-  version: '0'
-  source:
-    type: stdlib
-- name: stringio
-  version: '0'
-  source:
-    type: stdlib
-- name: strscan
-  version: '0'
-  source:
-    type: stdlib
-- name: tempfile
-  version: '0'
-  source:
-    type: stdlib
-- name: time
-  version: '0'
-  source:
-    type: stdlib
 - name: timeout
   version: '0'
   source:
     type: stdlib
-- name: tsort
-  version: '0'
-  source:
-    type: stdlib
-- name: tzinfo
-  version: '2.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: uri
   version: '0'
   source:
@@ -270,19 +74,7 @@ gems:
   source:
     type: git
     name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
-- name: webrick
-  version: 1.9.1
-  source:
-    type: rubygems
-- name: yard
-  version: '0.9'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 1e026936df951c269b64b7cba278132b0af42828
+    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
 gemfile_lock_path: Gemfile.lock

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -33,6 +33,10 @@ gems:
     revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: digest
+  version: '0'
+  source:
+    type: stdlib
 - name: fileutils
   version: '0'
   source:
@@ -45,11 +49,19 @@ gems:
     revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: json
+  version: '0'
+  source:
+    type: stdlib
 - name: net-http
   version: '0'
   source:
     type: stdlib
 - name: net-protocol
+  version: '0'
+  source:
+    type: stdlib
+- name: openssl
   version: '0'
   source:
     type: stdlib
@@ -61,6 +73,10 @@ gems:
     revision: 0ef449166f72c767f58f920cc36aca818fbf082f
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: socket
+  version: '0'
+  source:
+    type: stdlib
 - name: timeout
   version: '0'
   source:

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -37,10 +37,6 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: fileutils
-  version: '0'
-  source:
-    type: stdlib
 - name: hashdiff
   version: '1.1'
   source:
@@ -65,14 +61,6 @@ gems:
   version: '0'
   source:
     type: stdlib
-- name: rake
-  version: '13.0'
-  source:
-    type: git
-    name: ruby/gem_rbs_collection
-    revision: 0ef449166f72c767f58f920cc36aca818fbf082f
-    remote: https://github.com/ruby/gem_rbs_collection.git
-    repo_dir: gems
 - name: socket
   version: '0'
   source:

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -15,7 +15,9 @@ path: .gem_rbs_collection
 
 gems:
   # stdlibs
+  - name: json
   - name: net-http
+  - name: openssl
   - name: uri
   # unused library in line-bot-api and its test
   - name: rack

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -34,3 +34,5 @@ gems:
     ignore: true
   - name: yard
     ignore: true
+  - name: rake
+    ignore: true

--- a/rbs_collection.yaml
+++ b/rbs_collection.yaml
@@ -17,3 +17,18 @@ gems:
   # stdlibs
   - name: net-http
   - name: uri
+  # unused library in line-bot-api and its test
+  - name: rack
+    ignore: true
+  - name: rackup
+    ignore: true
+  - name: rbs
+    ignore: true
+  - name: rubocop
+    ignore: true
+  - name: steep
+    ignore: true
+  - name: webrick
+    ignore: true
+  - name: yard
+    ignore: true


### PR DESCRIPTION
Renovate task failed, because it tries to update dependencies, but `rbs_collection.lock.yaml` is not updated by the renovate.

The `rbs_collection.lock.yaml` file lists libraries that include RBS. Ideally, it should contain only those necessary for generating RBS for line-bot-sdk-ruby and for type-checking with steep. However, it currently includes many unnecessary libraries. Let's ignore libraries not being used as RBS targets. This will make renovate version upgrades less prone to failure.

Reference: https://github.com/ruby/rbs/blob/66c2c915989c4d5bccce23349d450e3d4464b51e/docs/collection.md

After merging this, https://github.com/line/line-bot-sdk-ruby/pull/599 must be passed.