### PR TITLE
Fix pebble for array-type query parameter

### DIFF
--- a/generator/src/main/resources/line-bot-sdk-ruby-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-generator/api.pebble
@@ -59,7 +59,7 @@ module Line
           # This returns an array containing response, HTTP status code, and header in order. Please specify all header keys in lowercase.
           #
           {% for param in op.allParams -%}
-          # @param {{param.paramName}} [{{ param.dataType }}{{ param.required ? '' : ', nil' }}] {{param.description}}
+          # @param {{param.paramName}} [{{ formatDataType(param) }}{{ param.required ? '' : ', nil' }}] {{param.description}}
           {% endfor -%}
           {% if op.isDeprecated -%}
           # @deprecated
@@ -93,7 +93,11 @@ module Line
               {% endfor %}
             }.compact{% elseif op.hasQueryParams %}
             query_params = {{ '{' }}{% for param in op.queryParams %}
+              {%- if param.isArray %}
+              "{{ param.baseName }}": {{ param.paramName }}&.join(','){{ loop.last ? '' : ',' -}}
+              {%- else %}
               "{{ param.baseName }}": {{ param.paramName }}{{ loop.last ? '' : ',' -}}
+              {%- endif %}
               {% endfor %}
             }.compact{% endif %}{% if op.hasHeaderParams %}
             header_params = {{ '{' }}{% for param in op.headerParams %}
@@ -133,7 +137,7 @@ module Line
           # When you want to get HTTP status code or response headers, use {{ '{#' }}{{op.nickname}}_with_http_info} instead of this.
           #
           {% for param in op.allParams -%}
-          # @param {{param.paramName}} [{{ param.dataType }}{{ param.required ? '' : ', nil' }}] {{param.description}}
+          # @param {{param.paramName}} [{{ formatDataType(param) }}{{ param.required ? '' : ', nil' }}] {{param.description}}
           {% endfor -%}
           {% if op.isDeprecated -%}
           # @deprecated
@@ -168,3 +172,7 @@ module Line
     end
   end
 end
+
+{%- macro formatDataType(param) -%}
+{%- if param.isArray -%}Array[{{ param.items.dataType }}]{%- else -%}{{ param.dataType }}{%- endif -%}
+{%- endmacro -%}

--- a/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
+++ b/generator/src/main/resources/line-bot-sdk-ruby-rbs-generator/api.pebble
@@ -54,7 +54,7 @@ module Line
           # This returns an array containing response, HTTP status code, and header in order. Please specify all header keys in lowercase.
           #
           {% for param in op.allParams -%}
-          # @param {{param.paramName}} [{{ param.dataType }}{{ param.required ? '' : ', nil' }}] {{param.description}}
+          # @param {{param.paramName}} [{{ formatDataType(param) }}{{ param.required ? '' : ', nil' }}] {{param.description}}
           {% endfor -%}
           {% if op.isDeprecated -%}
           # @deprecated
@@ -75,7 +75,7 @@ module Line
           # @return [Array((String|nil), Integer, Hash{String => String})] when other HTTP status code is returned. String is HTTP response body itself.
           def {{op.nickname}}_with_http_info: (
             {%- for param in op.allParams %}
-            {{ param.required ? '' : '?' }}{{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
+            {{ param.required ? '' : '?' }}{{param.paramName}}: {{ formatDataType(param) }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
             {% endfor %}
           ) -> (
             {%- for response in op.responses %}
@@ -89,7 +89,7 @@ module Line
           # When you want to get HTTP status code or response headers, use {{ '{#' }}{{op.nickname}}_with_http_info} instead of this.
           #
           {% for param in op.allParams -%}
-          # @param {{param.paramName}} [{{ param.dataType }}{{ param.required ? '' : ', nil' }}] {{param.description}}
+          # @param {{param.paramName}} [{{ formatDataType(param) }}{{ param.required ? '' : ', nil' }}] {{param.description}}
           {% endfor -%}
           {% if op.isDeprecated -%}
           # @deprecated
@@ -110,7 +110,7 @@ module Line
           # @return [String, nil] when other HTTP status code is returned. This String is HTTP response body itself.
           def {{op.nickname}}: (
             {%- for param in op.allParams %}
-            {{ param.required ? '' : '?' }}{{param.paramName}}: {{ param.dataType }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
+            {{ param.required ? '' : '?' }}{{param.paramName}}: {{ formatDataType(param) }}{{ param.required ? '' : '?' }}{{ loop.last ? '' : ', ' -}}
             {% endfor %}
           ) -> (
             {%- for response in op.responses %}
@@ -124,3 +124,7 @@ module Line
     end
   end
 end
+
+{%- macro formatDataType(param) -%}
+{%- if param.isArray -%}Array[{{ param.items.dataType }}]{%- else -%}{{ param.dataType }}{%- endif -%}
+{%- endmacro -%}


### PR DESCRIPTION
## Description
This PR addresses a modification to the generator responsible for producing the Ruby SDK from OpenAPI definitions. Specifically, it introduces support for query parameters that include arrays.

## Changes
Enhanced the generator to handle array-type query parameters.

Here is an example of how such an API call might look in a shell script:
```sh
curl -X GET "https://api.line.me/v2/bot/example?param=value1&param=value2"
```

## Note
Currently, there are no endpoints that utilize such parameters. However, this update is a preparatory step for future API enhancements.