### PR TITLE
Update dependency in example

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   arm64-darwin-24
   x86_64-linux
 

--- a/examples/v2/audience/Gemfile.lock
+++ b/examples/v2/audience/Gemfile.lock
@@ -8,12 +8,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
+    base64 (0.3.0)
     multipart-post (2.4.1)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   line-bot-api!

--- a/examples/v2/channel_access_token/Gemfile.lock
+++ b/examples/v2/channel_access_token/Gemfile.lock
@@ -8,12 +8,13 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
+    base64 (0.3.0)
     multipart-post (2.4.1)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   line-bot-api!

--- a/examples/v2/echobot/Gemfile
+++ b/examples/v2/echobot/Gemfile
@@ -8,4 +8,3 @@ gem 'line-bot-api', path: '../../..' # delete this `path: ...`, and specify the 
 gem "puma"
 gem "rackup"
 gem "sinatra"
-gem "webrick"

--- a/examples/v2/echobot/Gemfile.lock
+++ b/examples/v2/echobot/Gemfile.lock
@@ -8,38 +8,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
+    base64 (0.3.0)
     logger (1.7.0)
     multipart-post (2.4.1)
-    mustermann (3.0.3)
-      ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.4)
-    puma (6.6.0)
+    mustermann (3.1.1)
+    nio4r (2.7.5)
+    puma (8.0.2)
       nio4r (~> 2.0)
-    rack (3.1.13)
-    rack-protection (4.1.1)
+    rack (3.2.6)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.0)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
-    ruby2_keywords (0.0.5)
-    sinatra (4.1.1)
+    sinatra (4.2.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
       rack (>= 3.0.0, < 4)
-      rack-protection (= 4.1.1)
+      rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    tilt (2.6.0)
-    webrick (1.9.1)
+    tilt (2.7.0)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -47,7 +45,6 @@ DEPENDENCIES
   puma
   rackup
   sinatra
-  webrick
 
 BUNDLED WITH
    2.4.10

--- a/examples/v2/kitchensink/Gemfile
+++ b/examples/v2/kitchensink/Gemfile
@@ -7,4 +7,3 @@ gem 'line-bot-api', path: '../../..' # delete this `path: ...`, and specify the 
 gem "puma"
 gem "rackup"
 gem "sinatra"
-gem "webrick"

--- a/examples/v2/kitchensink/Gemfile.lock
+++ b/examples/v2/kitchensink/Gemfile.lock
@@ -8,38 +8,36 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    base64 (0.2.0)
+    base64 (0.3.0)
     logger (1.7.0)
     multipart-post (2.4.1)
-    mustermann (3.0.3)
-      ruby2_keywords (~> 0.0.1)
-    nio4r (2.7.4)
-    puma (6.6.0)
+    mustermann (3.1.1)
+    nio4r (2.7.5)
+    puma (8.0.2)
       nio4r (~> 2.0)
-    rack (3.1.13)
-    rack-protection (4.1.1)
+    rack (3.2.6)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
       logger (>= 1.6.0)
       rack (>= 3.0.0, < 4)
-    rack-session (2.1.0)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
-    rackup (2.2.1)
+    rackup (2.3.1)
       rack (>= 3)
-    ruby2_keywords (0.0.5)
-    sinatra (4.1.1)
+    sinatra (4.2.1)
       logger (>= 1.6.0)
       mustermann (~> 3.0)
       rack (>= 3.0.0, < 4)
-      rack-protection (= 4.1.1)
+      rack-protection (= 4.2.1)
       rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
-    tilt (2.6.0)
-    webrick (1.9.1)
+    tilt (2.7.0)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES
@@ -47,7 +45,6 @@ DEPENDENCIES
   puma
   rackup
   sinatra
-  webrick
 
 BUNDLED WITH
    2.4.10

--- a/examples/v2/rich_menu/Gemfile.lock
+++ b/examples/v2/rich_menu/Gemfile.lock
@@ -2,16 +2,19 @@ PATH
   remote: ../../..
   specs:
     line-bot-api (0.0.1.pre.test)
-      multipart-post (~> 2.4.1)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    base64 (0.3.0)
     multipart-post (2.4.1)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-22
+  arm64-darwin-23
 
 DEPENDENCIES
   line-bot-api!


### PR DESCRIPTION
https://github.com/line/line-bot-sdk-ruby/security recommends dependency upgrade, so this change tries it.

I've tested in my local.