### PR TITLE
Make renovate manage dependency in examples

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -118,6 +118,21 @@ task :build_test do
   sh "rm -rf metadata.gz"
 end
 
+desc "bundle install + syntax-check each examples/v2/* (uses published line-bot-api)"
+task :examples do
+  examples_root = File.expand_path("examples/v2", __dir__)
+  Dir.children(examples_root).sort.each do |name|
+    dir = File.join(examples_root, name)
+    next unless File.directory?(dir) && File.exist?(File.join(dir, "Gemfile"))
+
+    puts "==> examples/v2/#{name}"
+    Bundler.with_unbundled_env do
+      sh "bundle install", chdir: dir
+      sh "ruby -c app.rb", chdir: dir
+    end
+  end
+end
+
 desc "Run all tasks for development check and test"
 task :ci do
   Rake::Task[:test].invoke
@@ -127,4 +142,5 @@ task :ci do
   Rake::Task[:rbs_steep].invoke
   Rake::Task[:rbs_test].invoke
   Rake::Task[:build_test].invoke
+  Rake::Task[:examples].invoke
 end

--- a/examples/v2/audience/Gemfile
+++ b/examples/v2/audience/Gemfile
@@ -5,4 +5,10 @@ source "https://rubygems.org", cooldown: 7
 # Pin bundler so Renovate keeps it up to date (BUNDLED WITH alone is not tracked by Renovate)
 gem 'bundler', '~> 4.0.13'
 
-gem 'line-bot-api', path: '../../..' # delete this `path: ...`, and specify the latest version of line-bot-api when you want to use this example out side of this repository.
+# For SDK contributors: set USE_LOCAL_LINE_BOT_SDK_RUBY=1 to use the local checkout in this repository.
+# Otherwise the published gem is used; Renovate keeps the lower bound up to date.
+if ENV['USE_LOCAL_LINE_BOT_SDK_RUBY']
+  gem 'line-bot-api', path: '../../..'
+else
+  gem 'line-bot-api', '>= 2.8.3'
+end

--- a/examples/v2/audience/Gemfile.lock
+++ b/examples/v2/audience/Gemfile.lock
@@ -1,29 +1,24 @@
-PATH
-  remote: ../../..
-  specs:
-    line-bot-api (0.0.1.pre.test)
-      base64 (~> 0.2)
-      multipart-post (~> 2.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
+    line-bot-api (2.8.3)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
     multipart-post (2.4.1)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
   arm64-darwin-23
+  ruby
 
 DEPENDENCIES
   bundler (~> 4.0.13)
-  line-bot-api!
+  line-bot-api (>= 2.8.3)
 
 CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
-  line-bot-api (0.0.1.pre.test)
+  line-bot-api (2.8.3) sha256=c695ea0413228e3a69b89b3df93431ba70dd255004b9214763172423acd5b740
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
 
 BUNDLED WITH

--- a/examples/v2/audience/README.md
+++ b/examples/v2/audience/README.md
@@ -11,3 +11,14 @@ $ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```
+
+## Use local SDK (for SDK contributors)
+
+When developing the SDK in this repository, set `USE_LOCAL_LINE_BOT_SDK_RUBY=1`
+so that `bundle install` resolves `line-bot-api` from the local checkout (`../../..`) instead of RubyGems:
+
+```sh
+$ USE_LOCAL_LINE_BOT_SDK_RUBY=1 bundle install
+```
+
+When `USE_LOCAL_LINE_BOT_SDK_RUBY` is unset, the published gem from RubyGems is used.

--- a/examples/v2/channel_access_token/Gemfile
+++ b/examples/v2/channel_access_token/Gemfile
@@ -5,4 +5,10 @@ source "https://rubygems.org", cooldown: 7
 # Pin bundler so Renovate keeps it up to date (BUNDLED WITH alone is not tracked by Renovate)
 gem 'bundler', '~> 4.0.13'
 
-gem 'line-bot-api', path: '../../..' # delete this `path: ...`, and specify the latest version of line-bot-api when you want to use this example out side of this repository.
+# For SDK contributors: set USE_LOCAL_LINE_BOT_SDK_RUBY=1 to use the local checkout in this repository.
+# Otherwise the published gem is used; Renovate keeps the lower bound up to date.
+if ENV['USE_LOCAL_LINE_BOT_SDK_RUBY']
+  gem 'line-bot-api', path: '../../..'
+else
+  gem 'line-bot-api', '>= 2.8.3'
+end

--- a/examples/v2/channel_access_token/Gemfile.lock
+++ b/examples/v2/channel_access_token/Gemfile.lock
@@ -1,29 +1,24 @@
-PATH
-  remote: ../../..
-  specs:
-    line-bot-api (0.0.1.pre.test)
-      base64 (~> 0.2)
-      multipart-post (~> 2.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
+    line-bot-api (2.8.3)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
     multipart-post (2.4.1)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
   arm64-darwin-23
+  ruby
 
 DEPENDENCIES
   bundler (~> 4.0.13)
-  line-bot-api!
+  line-bot-api (>= 2.8.3)
 
 CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
-  line-bot-api (0.0.1.pre.test)
+  line-bot-api (2.8.3) sha256=c695ea0413228e3a69b89b3df93431ba70dd255004b9214763172423acd5b740
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
 
 BUNDLED WITH

--- a/examples/v2/channel_access_token/README.md
+++ b/examples/v2/channel_access_token/README.md
@@ -10,3 +10,14 @@ $ export LINE_CHANNEL_SECRET=YOUR_CHANNEL_SECRET
 $ bundle install
 $ bundle exec ruby app.rb
 ```
+
+## Use local SDK (for SDK contributors)
+
+When developing the SDK in this repository, set `USE_LOCAL_LINE_BOT_SDK_RUBY=1`
+so that `bundle install` resolves `line-bot-api` from the local checkout (`../../..`) instead of RubyGems:
+
+```sh
+$ USE_LOCAL_LINE_BOT_SDK_RUBY=1 bundle install
+```
+
+When `USE_LOCAL_LINE_BOT_SDK_RUBY` is unset, the published gem from RubyGems is used.

--- a/examples/v2/echobot/Gemfile
+++ b/examples/v2/echobot/Gemfile
@@ -5,7 +5,13 @@ source "https://rubygems.org", cooldown: 7
 # Pin bundler so Renovate keeps it up to date (BUNDLED WITH alone is not tracked by Renovate)
 gem 'bundler', '~> 4.0.13'
 
-gem 'line-bot-api', path: '../../..' # delete this `path: ...`, and specify the latest version of line-bot-api when you want to use this example out side of this repository.
+# For SDK contributors: set USE_LOCAL_LINE_BOT_SDK_RUBY=1 to use the local checkout in this repository.
+# Otherwise the published gem is used; Renovate keeps the lower bound up to date.
+if ENV['USE_LOCAL_LINE_BOT_SDK_RUBY']
+  gem 'line-bot-api', path: '../../..'
+else
+  gem 'line-bot-api', '>= 2.8.3'
+end
 gem "puma"
 gem "rackup"
 gem "sinatra"

--- a/examples/v2/echobot/Gemfile.lock
+++ b/examples/v2/echobot/Gemfile.lock
@@ -1,14 +1,10 @@
-PATH
-  remote: ../../..
-  specs:
-    line-bot-api (0.0.1.pre.test)
-      base64 (~> 0.2)
-      multipart-post (~> 2.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
+    line-bot-api (2.8.3)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
     logger (1.7.0)
     multipart-post (2.4.1)
     mustermann (3.1.1)
@@ -35,14 +31,12 @@ GEM
     tilt (2.7.0)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
   arm64-darwin-23
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   bundler (~> 4.0.13)
-  line-bot-api!
+  line-bot-api (>= 2.8.3)
   puma
   rackup
   sinatra
@@ -50,7 +44,7 @@ DEPENDENCIES
 CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
-  line-bot-api (0.0.1.pre.test)
+  line-bot-api (2.8.3) sha256=c695ea0413228e3a69b89b3df93431ba70dd255004b9214763172423acd5b740
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mustermann (3.1.1) sha256=4c6170c7234d5499c345562ba7c7dfe73e1754286dcc1abb053064d66a127198

--- a/examples/v2/echobot/README.md
+++ b/examples/v2/echobot/README.md
@@ -12,3 +12,14 @@ $ export APP_BASE_URL="https://your.base.url:4567"
 $ bundle exec ruby app.rb
 ```
 
+## Use local SDK (for SDK contributors)
+
+When developing the SDK in this repository, set `USE_LOCAL_LINE_BOT_SDK_RUBY=1`
+so that `bundle install` resolves `line-bot-api` from the local checkout (`../../..`) instead of RubyGems:
+
+```sh
+$ USE_LOCAL_LINE_BOT_SDK_RUBY=1 bundle install
+```
+
+When `USE_LOCAL_LINE_BOT_SDK_RUBY` is unset, the published gem from RubyGems is used.
+

--- a/examples/v2/kitchensink/Gemfile
+++ b/examples/v2/kitchensink/Gemfile
@@ -5,7 +5,13 @@ source "https://rubygems.org", cooldown: 7
 # Pin bundler so Renovate keeps it up to date (BUNDLED WITH alone is not tracked by Renovate)
 gem 'bundler', '~> 4.0.13'
 
-gem 'line-bot-api', path: '../../..' # delete this `path: ...`, and specify the latest version of line-bot-api when you want to use this example out side of this repository.
+# For SDK contributors: set USE_LOCAL_LINE_BOT_SDK_RUBY=1 to use the local checkout in this repository.
+# Otherwise the published gem is used; Renovate keeps the lower bound up to date.
+if ENV['USE_LOCAL_LINE_BOT_SDK_RUBY']
+  gem 'line-bot-api', path: '../../..'
+else
+  gem 'line-bot-api', '>= 2.8.3'
+end
 gem "puma"
 gem "rackup"
 gem "sinatra"

--- a/examples/v2/kitchensink/Gemfile.lock
+++ b/examples/v2/kitchensink/Gemfile.lock
@@ -1,14 +1,10 @@
-PATH
-  remote: ../../..
-  specs:
-    line-bot-api (0.0.1.pre.test)
-      base64 (~> 0.2)
-      multipart-post (~> 2.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
+    line-bot-api (2.8.3)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
     logger (1.7.0)
     multipart-post (2.4.1)
     mustermann (3.1.1)
@@ -35,14 +31,12 @@ GEM
     tilt (2.7.0)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
   arm64-darwin-23
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   bundler (~> 4.0.13)
-  line-bot-api!
+  line-bot-api (>= 2.8.3)
   puma
   rackup
   sinatra
@@ -50,7 +44,7 @@ DEPENDENCIES
 CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
-  line-bot-api (0.0.1.pre.test)
+  line-bot-api (2.8.3) sha256=c695ea0413228e3a69b89b3df93431ba70dd255004b9214763172423acd5b740
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mustermann (3.1.1) sha256=4c6170c7234d5499c345562ba7c7dfe73e1754286dcc1abb053064d66a127198

--- a/examples/v2/kitchensink/README.md
+++ b/examples/v2/kitchensink/README.md
@@ -12,3 +12,14 @@ $ bundle install
 $ export APP_BASE_URL="https://your.base.url:4567"
 $ bundle exec ruby app.rb
 ```
+
+## Use local SDK (for SDK contributors)
+
+When developing the SDK in this repository, set `USE_LOCAL_LINE_BOT_SDK_RUBY=1`
+so that `bundle install` resolves `line-bot-api` from the local checkout (`../../..`) instead of RubyGems:
+
+```sh
+$ USE_LOCAL_LINE_BOT_SDK_RUBY=1 bundle install
+```
+
+When `USE_LOCAL_LINE_BOT_SDK_RUBY` is unset, the published gem from RubyGems is used.

--- a/examples/v2/rich_menu/Gemfile
+++ b/examples/v2/rich_menu/Gemfile
@@ -5,4 +5,10 @@ source "https://rubygems.org", cooldown: 7
 # Pin bundler so Renovate keeps it up to date (BUNDLED WITH alone is not tracked by Renovate)
 gem 'bundler', '~> 4.0.13'
 
-gem 'line-bot-api', path: '../../..' # delete this `path: ...`, and specify the latest version of line-bot-api when you want to use this example out side of this repository.
+# For SDK contributors: set USE_LOCAL_LINE_BOT_SDK_RUBY=1 to use the local checkout in this repository.
+# Otherwise the published gem is used; Renovate keeps the lower bound up to date.
+if ENV['USE_LOCAL_LINE_BOT_SDK_RUBY']
+  gem 'line-bot-api', path: '../../..'
+else
+  gem 'line-bot-api', '>= 2.8.3'
+end

--- a/examples/v2/rich_menu/Gemfile.lock
+++ b/examples/v2/rich_menu/Gemfile.lock
@@ -1,29 +1,24 @@
-PATH
-  remote: ../../..
-  specs:
-    line-bot-api (0.0.1.pre.test)
-      base64 (~> 0.2)
-      multipart-post (~> 2.4)
-
 GEM
   remote: https://rubygems.org/
   specs:
     base64 (0.3.0)
+    line-bot-api (2.8.3)
+      base64 (~> 0.2)
+      multipart-post (~> 2.4)
     multipart-post (2.4.1)
 
 PLATFORMS
-  arm64-darwin-21
-  arm64-darwin-22
   arm64-darwin-23
+  ruby
 
 DEPENDENCIES
   bundler (~> 4.0.13)
-  line-bot-api!
+  line-bot-api (>= 2.8.3)
 
 CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
-  line-bot-api (0.0.1.pre.test)
+  line-bot-api (2.8.3) sha256=c695ea0413228e3a69b89b3df93431ba70dd255004b9214763172423acd5b740
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
 
 BUNDLED WITH

--- a/examples/v2/rich_menu/README.md
+++ b/examples/v2/rich_menu/README.md
@@ -10,3 +10,14 @@ $ export LINE_CHANNEL_ACCESS_TOKEN=YOUR_CHANNEL_ACCESS_TOKEN
 $ bundle install
 $ bundle exec ruby app.rb
 ```
+
+## Use local SDK (for SDK contributors)
+
+When developing the SDK in this repository, set `USE_LOCAL_LINE_BOT_SDK_RUBY=1`
+so that `bundle install` resolves `line-bot-api` from the local checkout (`../../..`) instead of RubyGems:
+
+```sh
+$ USE_LOCAL_LINE_BOT_SDK_RUBY=1 bundle install
+```
+
+When `USE_LOCAL_LINE_BOT_SDK_RUBY` is unset, the published gem from RubyGems is used.

--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,10 @@
   timezone: 'Asia/Tokyo',
   automerge: true,
   platformAutomerge: true,
+  // Override `config:recommended` defaults so that Renovate also updates dependencies under `examples/`.
+  ignorePaths: [
+    '**/test/**',
+  ],
   'git-submodules': {
     enabled: true,
   },


### PR DESCRIPTION
By default, Renovate ignores `examples`, so let's have renovate manage the example lock files as well.
We cannot write many tests for them, but we can at least check installation and script syntax.

Also, instead of using the local SDK by default, the examples now use the latest released version so users can easily copy and paste them.
At the same time, we still keep a way to use the local SDK, so this should not cause any problem for us.

