### PR TITLE
Enable lockfile maintenance by renovate

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,6 +14,12 @@
     'dependency upgrade',
   ],
   minimumReleaseAge : "7 days",
+  lockFileMaintenance: {
+    enabled: true,
+    schedule: [
+      'after 1am and before 4am',
+    ],
+  },
   packageRules: [
     {
       labels: [


### PR DESCRIPTION
https://github.com/line/line-bot-mcp-server/pull/470

In many cases, we don't have to handle upgrading libraries due to security issue. The option and automates it and resolves the issue.